### PR TITLE
App association file for iOS production app

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -3,6 +3,7 @@
         "details": [
             {
                 "appIDs": [
+                    "ZKG876RKJ8.io.gnosis.multisig.prod.mainnet",
                     "ZKG876RKJ8.io.gnosis.multisig.prerelease",
                     "ZKG876RKJ8.io.gnosis.multisig.dev.mainnet",
                     "ZKG876RKJ8.io.gnosis.multisig.dev.rinkeby",

--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,21 @@
+{
+    "applinks": {
+        "details": [
+            {
+                "appIDs": [
+                    "ZKG876RKJ8.io.gnosis.multisig.prerelease",
+                    "ZKG876RKJ8.io.gnosis.multisig.dev.mainnet",
+                    "ZKG876RKJ8.io.gnosis.multisig.dev.rinkeby",
+                    "ZKG876RKJ8.io.gnosis.multisig.staging.mainnet",
+                    "ZKG876RKJ8.io.gnosis.multisig.staging.rinkeby"
+                ],
+                "components": [
+                    {
+                        "/": "*",
+                        "comment": "Matches all universal links"
+                    }
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
This restores the state from before the launch of the new homepage last week. 
See: https://web.archive.org/web/20221229230859/https://safe.global/.well-known/apple-app-site-association

And this will hopefully fix: https://github.com/safe-global/safe-ios/issues/2951