### PR TITLE
fix: migrate Notion link

### DIFF
--- a/src/content/core.json
+++ b/src/content/core.json
@@ -207,7 +207,7 @@
     "buttons": [
       {
         "text": "Use our Hackathon Guide",
-        "href": "https://gnosis-safe.notion.site/Safe-d6c6ed61389041e28f5c7c925f653701",
+        "href": "https://safe-global.notion.site/Safe-d6c6ed61389041e28f5c7c925f653701",
         "variant": "button"
       },
       {


### PR DESCRIPTION
This updates the "Use our Hackathon Guide" link on the "Core" page to use our new Notion URL.