### PR TITLE
fix: Floating tiles performance

### DIFF
--- a/src/components/Careers/Intro/styles.module.css
+++ b/src/components/Careers/Intro/styles.module.css
@@ -17,7 +17,6 @@
   left: 50%;
   transform: translateX(-50%);
   top: -5%;
-  filter: url('#gooey');
   z-index: -1;
 }
 

--- a/src/components/Core/Tweets/styles.module.css
+++ b/src/components/Core/Tweets/styles.module.css
@@ -28,7 +28,6 @@
   top: 0px;
   left: 50%;
   transform: translateX(-50%);
-  filter: url('#gooey');
   z-index: -1;
 }
 

--- a/src/components/Wallet/Intro/styles.module.css
+++ b/src/components/Wallet/Intro/styles.module.css
@@ -33,7 +33,6 @@
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
-  filter: url('#gooey');
   z-index: -1;
 }
 


### PR DESCRIPTION
## What it solves

Resolves #160 

## How this PR fixes it

- Removes the filter on the svg animations

Note: Keeps the filter on the interactive animations as these are disabled automatically on Safari (most likely because the tiles themselves are not part of an svg) but still work in Chrome and Firefox. This could be a possible refactor in the future to have the tile animations as divs.

## How to test

1. Open the homepage on Safari
2. Navigate to `/core`, `/wallet`, `careers`
3. Observe the tile animations are no longer choppy