### PR TITLE
chore: Bump version to 1.0.3

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2023 Safe Ecosystem Foundation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# Safe Homepage
+
+![license](https://img.shields.io/github/license/safe-global/safe-homepage)
+![release](https://img.shields.io/github/v/release/safe-global/safe-homepage)
+
 ## Getting Started
 
 These instructions will help you get a copy of the project up and running on your local machine for development and testing purposes.

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
-  "name": "safe-landing-page",
-  "homepage": "https://github.com/safe-global/safe-landing-page",
-  "license": "GPL-3.0",
-  "version": "0.1.1",
+  "name": "safe-homepage",
+  "homepage": "https://github.com/safe-global/safe-homepage",
+  "version": "1.0.3",
   "scripts": {
     "build": "next build && next export",
     "lint": "tsc && next lint",


### PR DESCRIPTION
## What it solves

- Bumps version to 1.0.3
- Adds license info (see https://github.com/safe-global/safe-landing-page/blob/dev/LICENSE.md)