### PR TITLE
fix: add border to "New!" badge

### DIFF
--- a/src/components/Wallet/NetworkChip/styles.module.css
+++ b/src/components/Wallet/NetworkChip/styles.module.css
@@ -27,6 +27,7 @@
   color: var(--mui-palette-text-dark);
   padding: 0 8px;
   border-radius: 16px;
+  border: 2px solid var(--mui-palette-background-default);
   position: absolute;
   top: -10px;
   right: -10px;


### PR DESCRIPTION
This adds a border to the "New!" badge according to [the design](https://www.figma.com/file/doceHL65jwlEbAGegLRnq2/Landing-Page?node-id=22-48&t=ZSmtJuZGskLaNgTs-0):

![image](https://user-images.githubusercontent.com/20442784/233653158-9494f74b-a65f-4261-bbab-32f0a374334e.png)