### PR TITLE
fix: Don't cut off network chip New tag

### DIFF
--- a/src/components/Wallet/NetworkChip/index.tsx
+++ b/src/components/Wallet/NetworkChip/index.tsx
@@ -14,7 +14,7 @@ export type NetworkChipProps = {
 const NetworkChip = ({ name, icon, textColor, backgroundColor, isNew }: NetworkChipProps) => (
   <Box className={css.wrapper} sx={{ backgroundColor }}>
     <div className={css.icon}>
-      <img {...icon} />
+      <img {...icon} width={40} height={40} />
     </div>
     <Typography className={css.name} variant="body1" color={textColor}>
       {name}

--- a/src/components/Wallet/NetworkChip/styles.module.css
+++ b/src/components/Wallet/NetworkChip/styles.module.css
@@ -11,8 +11,6 @@
 .icon img {
   display: flex;
   align-items: center;
-  height: 40px;
-  width: 40px;
 }
 
 .name {

--- a/src/components/common/Networks/index.tsx
+++ b/src/components/common/Networks/index.tsx
@@ -1,11 +1,12 @@
+import { shuffle } from 'lodash'
 import type { NetworkChipProps } from '@/components/Wallet/NetworkChip'
 import NetworkChip from '@/components/Wallet/NetworkChip'
-import { Box, Typography } from '@mui/material'
+import { Typography } from '@mui/material'
 import clsx from 'clsx'
 import css from './styles.module.css'
 import layoutCss from '@/components/common/styles.module.css'
 import { type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
-import { useContext } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import ChainsContext from '../ChainsContext'
 
 export type ChainProps = {
@@ -26,15 +27,7 @@ type NetworksProps = {
   chainsData: ChainProps[]
 }
 
-const NetworksRow = ({
-  showNew,
-  networksRow,
-  chainsData,
-}: {
-  showNew?: boolean
-  networksRow: NetworkChipProps[]
-  chainsData: ChainProps[]
-}) => {
+const NetworksRow = ({ networksRow, chainsData }: { networksRow: NetworkChipProps[]; chainsData: ChainProps[] }) => {
   return (
     <>
       {networksRow.map(({ name, icon, textColor, backgroundColor, isNew }, i) => {
@@ -43,15 +36,19 @@ const NetworksRow = ({
           textColor: chainData?.textColor || textColor || defaultThemeColors.textColor,
           backgroundColor: chainData?.backgroundColor || backgroundColor || defaultThemeColors.backgroundColor,
         }
-        return <NetworkChip key={`${name}_${i}`} icon={icon} name={name} isNew={isNew && showNew} {...chainColors} />
+        return <NetworkChip key={`${name}_${i}`} icon={icon} name={name} isNew={isNew} {...chainColors} />
       })}
     </>
   )
 }
 
 const Networks = ({ title, text, networks }: NetworksProps) => {
+  const [shuffledNetworks, setShuffledNetworks] = useState<NetworkChipProps[]>([])
   const chainsData = useContext(ChainsContext)
-  const shuffledNetworks = networks.slice(2, 8).reverse().concat(networks.slice(8).reverse(), networks.slice(0, 2))
+
+  useEffect(() => {
+    setShuffledNetworks(shuffle(networks))
+  }, [networks])
 
   return (
     <div className={layoutCss.containerMedium}>
@@ -60,12 +57,18 @@ const Networks = ({ title, text, networks }: NetworksProps) => {
       </Typography>
       <div className={css.networksWrapper}>
         <div className={css.gradientBase} />
-        {[0, 1].map((index) => (
-          <Box key={index} display="flex" gap="8px" className={index === 0 ? css.slider : css.sliderReverse}>
-            <NetworksRow networksRow={networks} chainsData={chainsData} showNew={index === 1} />
-            <NetworksRow networksRow={shuffledNetworks} chainsData={chainsData} showNew={index === 1} />
-          </Box>
-        ))}
+        <div className={css.animation}>
+          <div className={css.slider}>
+            <NetworksRow networksRow={networks} chainsData={chainsData} />
+            <NetworksRow networksRow={networks} chainsData={chainsData} />
+          </div>
+        </div>
+        <div className={clsx(css.animation, css.animationReverse)}>
+          <div className={css.slider}>
+            <NetworksRow networksRow={shuffledNetworks} chainsData={chainsData} />
+            <NetworksRow networksRow={shuffledNetworks} chainsData={chainsData} />
+          </div>
+        </div>
         <div className={clsx(css.gradientBase, css.gradientFlipped)} />
       </div>
       <Typography className={css.secondaryText} variant="body1">

--- a/src/components/common/Networks/styles.module.css
+++ b/src/components/common/Networks/styles.module.css
@@ -4,9 +4,7 @@
   flex-direction: column;
   gap: 16px;
   overflow: hidden;
-
-  --topRowWidth: 1483px;
-  --bottomRowWidth: 1448px;
+  padding: 8px 0;
 }
 
 .gradientBase {
@@ -32,30 +30,36 @@
   color: var(--mui-palette-primary-light);
 }
 
-.slider {
-  animation: slide 59s linear infinite;
+.animation {
+  animation-iteration-count: infinite;
+  animation-timing-function: linear;
+  display: flex;
+  width: max-content;
+  min-width: 200%;
+  animation-duration: 100s;
+  animation-delay: 0s;
+  animation-play-state: running;
+  animation-name: slide;
+  gap: 8px;
 }
 
-.sliderReverse {
-  transform: translateX(calc(var(--bottomRowWidth) * -1));
-  animation: slide-reverse 60s linear infinite;
+.animationReverse {
+  animation-direction: reverse;
+}
+
+.slider {
+  display: flex;
+  gap: 8px;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  font-size: 0;
 }
 
 @keyframes slide {
-  from {
-    transform: translateX(0);
-  }
   to {
-    transform: translateX(calc(var(--topRowWidth) * -1));
-  }
-}
-
-@keyframes slide-reverse {
-  from {
-    transform: translateX(calc(var(--bottomRowWidth) * -1));
-  }
-  to {
-    transform: translateX(0);
+    transform: translate(-50%)
   }
 }
 


### PR DESCRIPTION
## What it solves

Resolves #184 

Also refactors the network rows to remove hard-coded values and instead rely on css properties to restart animation from the correct spot. There should be no jumps anymore no matter how many logos are added or removed.

## How to test

1. Open the safe-homepage
2. Scroll down to Networks
3. Observe the `New` Tag is visible in both rows

## Screenshot

<img width="1141" alt="Screenshot 2023-05-02 at 12 44 31" src="https://user-images.githubusercontent.com/5880855/235646035-e65c8a2b-c629-4f23-8f5d-42a5c413dafa.png">
