### PR TITLE
fix: remove position count from search results

### DIFF
--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -67,6 +67,12 @@ const Header = () => {
                   badgeContent={item.href === AppRoutes.careers ? positions.length : undefined}
                   color="primary"
                   className={css.badge}
+                  slotProps={{
+                    badge: {
+                      // @ts-expect-error - disable badge in search results
+                      'data-nosnippet': true,
+                    },
+                  }}
                 >
                   {item.label}
                 </Badge>


### PR DESCRIPTION
This resolves #180 by removing the open position count from Google via the [`data-nosnippet`](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag#data-nosnippet-attr) attribute.

![image](https://user-images.githubusercontent.com/20442784/235929361-839811c9-6055-48f1-b12b-1159951d94d2.png)