### PR TITLE
fix: no results message + loading indicator

### DIFF
--- a/src/components/Ecosystem/Projects/Projects.tsx
+++ b/src/components/Ecosystem/Projects/Projects.tsx
@@ -12,6 +12,7 @@ import {
   Toolbar,
   IconButton,
   Box,
+  CircularProgress,
 } from '@mui/material'
 import clsx from 'clsx'
 import { useMemo, useState } from 'react'
@@ -72,6 +73,8 @@ export const _getFilteredProjects = ({
   })
 }
 
+const DIVIDER_Y_MARGIN = 9
+
 const GRID_SPACING: GridProps['spacing'] = {
   xs: 2,
   md: '30px',
@@ -89,7 +92,7 @@ export const Projects = (): ReactElement => {
 
   const [pageLength, setPageLength] = useState(PAGE_LENGTH)
 
-  const { data: projects = [] } = useEcosystemData()
+  const { data: projects = [], isLoading } = useEcosystemData()
 
   // Categories
   const allCategories = useMemo(() => projects.flatMap(getProjectCategories), [projects])
@@ -198,89 +201,93 @@ export const Projects = (): ReactElement => {
           </Grid>
         </Grid>
 
-        <Divider sx={{ my: 9 }} />
+        <Divider sx={{ my: DIVIDER_Y_MARGIN }} />
 
-        <Grid container spacing={GRID_SPACING}>
-          <Grid item xs={12} md={3} display="flex" alignItems="center" justifyContent="space-between">
-            <Typography>
-              {searchResults.length}{' '}
-              <Typography color="primary.light" component="span">
-                result{searchResults.length === 1 ? '' : 's'}
-              </Typography>
-            </Typography>
-            <Button variant="outlined" className={css.filterButton} onClick={() => setIsFilterDrawerOpen(true)}>
-              <FilterIcon />
-              Filter
-            </Button>
-          </Grid>
-
-          <Grid item xs={12} md={9} className={css.chipContainer}>
-            {selectedCategories.map((category) => (
-              <Chip
-                key={category}
-                className={css.chip}
-                label={category}
-                onDelete={() => onSelectCategory(category, false)}
-                deleteIcon={<CrossIcon />}
-              />
-            ))}
-
-            {selectedIntegrations.map((integration) => (
-              <Chip
-                key={integration}
-                className={css.chip}
-                label={integration}
-                onDelete={() => onSelectIntegration(integration, false)}
-                deleteIcon={<CrossIcon />}
-              />
-            ))}
-
-            {selectedNetworks.map((network) => (
-              <Chip
-                key={network}
-                className={css.chip}
-                label={network}
-                onDelete={() => onSelectNetwork(network, false)}
-                deleteIcon={<CrossIcon />}
-              />
-            ))}
-          </Grid>
-
-          <Grid item xs={12} md={3} className={css.sidebar}>
-            {sidebar}
-          </Grid>
-
-          <Grid item xs={12} md={9}>
-            {visibleResults.length > 0 ? (
-              <Grid container spacing={GRID_SPACING} display="flex" alignContent="flex-start">
-                {visibleResults.map((project, idx) => (
-                  <Grid item xs={12} md={4} key={project.project + idx}>
-                    <ProjectCard {...project} />
-                  </Grid>
-                ))}
-                {shouldShowMoreButton && (
-                  <Grid item xs={12} display="flex" justifyContent="center">
-                    <Button variant="contained" size="large" onClick={onShowMore}>
-                      Show more
-                    </Button>
-                  </Grid>
-                )}
-              </Grid>
-            ) : (
-              <div style={{ textAlign: 'center' }}>
-                <SearchIcon />
-                <Typography variant="h4" my={2}>
-                  No results found for
-                  <br />
-                  {query}
+        {isLoading ? (
+          <div style={{ display: 'flex', justifyContent: 'center' }}>
+            <CircularProgress />
+          </div>
+        ) : (
+          <Grid container spacing={GRID_SPACING}>
+            <Grid item xs={12} md={3} display="flex" alignItems="center" justifyContent="space-between">
+              <Typography>
+                {searchResults.length}{' '}
+                <Typography color="primary.light" component="span">
+                  result{searchResults.length === 1 ? '' : 's'}
                 </Typography>
-                <Typography color="primary.light">Try searching something else</Typography>
-              </div>
-            )}
-          </Grid>
-        </Grid>
+              </Typography>
+              <Button variant="outlined" className={css.filterButton} onClick={() => setIsFilterDrawerOpen(true)}>
+                <FilterIcon />
+                Filter
+              </Button>
+            </Grid>
 
-        <Divider sx={{ my: '100px' }} />
+            <Grid item xs={12} md={9} className={css.chipContainer}>
+              {selectedCategories.map((category) => (
+                <Chip
+                  key={category}
+                  className={css.chip}
+                  label={category}
+                  onDelete={() => onSelectCategory(category, false)}
+                  deleteIcon={<CrossIcon />}
+                />
+              ))}
+
+              {selectedIntegrations.map((integration) => (
+                <Chip
+                  key={integration}
+                  className={css.chip}
+                  label={integration}
+                  onDelete={() => onSelectIntegration(integration, false)}
+                  deleteIcon={<CrossIcon />}
+                />
+              ))}
+
+              {selectedNetworks.map((network) => (
+                <Chip
+                  key={network}
+                  className={css.chip}
+                  label={network}
+                  onDelete={() => onSelectNetwork(network, false)}
+                  deleteIcon={<CrossIcon />}
+                />
+              ))}
+            </Grid>
+
+            <Grid item xs={12} md={3} className={css.sidebar}>
+              {sidebar}
+            </Grid>
+
+            <Grid item xs={12} md={9}>
+              {visibleResults.length > 0 ? (
+                <Grid container spacing={GRID_SPACING} display="flex" alignContent="flex-start">
+                  {visibleResults.map((project, idx) => (
+                    <Grid item xs={12} md={4} key={project.project + idx}>
+                      <ProjectCard {...project} />
+                    </Grid>
+                  ))}
+                  {shouldShowMoreButton && (
+                    <Grid item xs={12} display="flex" justifyContent="center">
+                      <Button variant="contained" size="large" onClick={onShowMore}>
+                        Show more
+                      </Button>
+                    </Grid>
+                  )}
+                </Grid>
+              ) : (
+                <div style={{ textAlign: 'center' }}>
+                  <SearchIcon />
+                  <Typography variant="h4" my={2}>
+                    No results found for {query || 'selected filters'}
+                  </Typography>
+                  <Typography color="primary.light">Try searching something else</Typography>
+                </div>
+              )}
+            </Grid>
+          </Grid>
+        )}
+
+        <Divider sx={{ my: DIVIDER_Y_MARGIN }} />
       </Container>
 
       <Dialog fullScreen open={isFilterDrawerOpen}>


### PR DESCRIPTION
This adds a loading indicator for the ecosystem projects, as well as fixing the no results message when only filters are selected.

![image](https://user-images.githubusercontent.com/20442784/236859289-7bb833bc-3408-4c8a-86d7-a5e197920801.png)

---

![image](https://user-images.githubusercontent.com/20442784/236859304-90e4185e-24e6-4ce4-a91c-f2955d28323b.png)

![image](https://user-images.githubusercontent.com/20442784/236859331-0548ba9b-c1c9-461d-ab24-c5d0a3594fb8.png)