### PR TITLE
feat: add pagination to search params

### DIFF
--- a/src/components/Ecosystem/Projects/Projects.tsx
+++ b/src/components/Ecosystem/Projects/Projects.tsx
@@ -17,6 +17,8 @@ import {
 } from '@mui/material'
 import clsx from 'clsx'
 import { useMemo, useState } from 'react'
+import { NextRouter, useRouter } from 'next/router'
+import NextLink from 'next/link'
 import type { GridProps } from '@mui/material'
 import type { Dispatch, ReactElement, SetStateAction } from 'react'
 
@@ -107,6 +109,16 @@ const GRID_SPACING: GridProps['spacing'] = {
 
 const PAGE_LENGTH = 12
 
+const PAGE_QUERY_PARAM = 'page'
+
+const getPage = (router: NextRouter): number => {
+  const query = Array.isArray(router.query[PAGE_QUERY_PARAM])
+    ? router.query[PAGE_QUERY_PARAM][0]
+    : router.query[PAGE_QUERY_PARAM]
+
+  return Number(query) || 1
+}
+
 export const Projects = ({ items }: BaseBlock): ReactElement => {
   const [query, setQuery] = useState('')
   const [isFilterDrawerOpen, setIsFilterDrawerOpen] = useState(false)
@@ -115,7 +127,9 @@ export const Projects = ({ items }: BaseBlock): ReactElement => {
   const [selectedIntegrations, setSelectedIntegrations] = useState(EMPTY_FILTER)
   const [selectedNetworks, setSelectedNetworks] = useState(EMPTY_FILTER)
 
-  const [pageLength, setPageLength] = useState(PAGE_LENGTH)
+  const router = useRouter()
+  const page = getPage(router)
+  const [pageLength, setPageLength] = useState(page * PAGE_LENGTH)
 
   const { data: projects = [], isLoading } = useEcosystemData()
 
@@ -336,9 +350,11 @@ export const Projects = ({ items }: BaseBlock): ReactElement => {
                   ))}
                   {shouldShowMoreButton && (
                     <Grid item xs={12} display="flex" justifyContent="center">
-                      <Button variant="contained" size="large" onClick={onShowMore}>
-                        Show more
-                      </Button>
+                      <NextLink href={{ query: { [PAGE_QUERY_PARAM]: page + 1 } }} shallow>
+                        <Button variant="contained" size="large" onClick={onShowMore}>
+                          Show more
+                        </Button>
+                      </NextLink>
                     </Grid>
                   )}
                 </Grid>

--- a/src/components/Ecosystem/Projects/Projects.tsx
+++ b/src/components/Ecosystem/Projects/Projects.tsx
@@ -17,8 +17,9 @@ import {
 } from '@mui/material'
 import clsx from 'clsx'
 import { useMemo, useState } from 'react'
-import { NextRouter, useRouter } from 'next/router'
+import { useRouter } from 'next/router'
 import NextLink from 'next/link'
+import type { NextRouter } from 'next/router'
 import type { GridProps } from '@mui/material'
 import type { Dispatch, ReactElement, SetStateAction } from 'react'
 
@@ -111,12 +112,10 @@ const PAGE_LENGTH = 12
 
 const PAGE_QUERY_PARAM = 'page'
 
-const getPage = (router: NextRouter): number => {
-  const query = Array.isArray(router.query[PAGE_QUERY_PARAM])
-    ? router.query[PAGE_QUERY_PARAM][0]
-    : router.query[PAGE_QUERY_PARAM]
+const getPage = (query: NextRouter['query']): number => {
+  const page = Array.isArray(query[PAGE_QUERY_PARAM]) ? query[PAGE_QUERY_PARAM][0] : query[PAGE_QUERY_PARAM]
 
-  return Number(query) || 1
+  return Number(page) || 1
 }
 
 export const Projects = ({ items }: BaseBlock): ReactElement => {
@@ -128,7 +127,7 @@ export const Projects = ({ items }: BaseBlock): ReactElement => {
   const [selectedNetworks, setSelectedNetworks] = useState(EMPTY_FILTER)
 
   const router = useRouter()
-  const page = getPage(router)
+  const page = getPage(router.query)
   const [pageLength, setPageLength] = useState(page * PAGE_LENGTH)
 
   const { data: projects = [], isLoading } = useEcosystemData()

--- a/src/components/Ecosystem/Projects/Projects.tsx
+++ b/src/components/Ecosystem/Projects/Projects.tsx
@@ -128,7 +128,6 @@ export const Projects = ({ items }: BaseBlock): ReactElement => {
 
   const router = useRouter()
   const page = getPage(router.query)
-  const [pageLength, setPageLength] = useState(page * PAGE_LENGTH)
 
   const { data: projects = [], isLoading } = useEcosystemData()
 
@@ -175,12 +174,6 @@ export const Projects = ({ items }: BaseBlock): ReactElement => {
     return onSelectCategory(category, !selectedCategories.includes(category))
   }
 
-  const onShowMore = () => {
-    setPageLength((val) => {
-      return val + PAGE_LENGTH
-    })
-  }
-
   const noFilters = useMemo(() => {
     return selectedCategories.length === 0 && selectedIntegrations.length === 0 && selectedNetworks.length === 0
   }, [selectedCategories, selectedIntegrations, selectedNetworks])
@@ -198,7 +191,7 @@ export const Projects = ({ items }: BaseBlock): ReactElement => {
   const searchResults = useProjectSearch(filteredProjects, query)
 
   // Paginated filtered/search-based results
-  const visibleResults = searchResults.slice(0, pageLength)
+  const visibleResults = searchResults.slice(0, PAGE_LENGTH * page)
 
   const shouldShowMoreButton = visibleResults.length < searchResults.length
 
@@ -355,7 +348,7 @@ export const Projects = ({ items }: BaseBlock): ReactElement => {
                         // Pagination marker for search engines
                         rel="next"
                       >
-                        <Button variant="contained" size="large" onClick={onShowMore}>
+                        <Button variant="contained" size="large">
                           Show more
                         </Button>
                       </NextLink>

--- a/src/components/Ecosystem/Projects/Projects.tsx
+++ b/src/components/Ecosystem/Projects/Projects.tsx
@@ -349,7 +349,12 @@ export const Projects = ({ items }: BaseBlock): ReactElement => {
                   ))}
                   {shouldShowMoreButton && (
                     <Grid item xs={12} display="flex" justifyContent="center">
-                      <NextLink href={{ query: { [PAGE_QUERY_PARAM]: page + 1 } }} shallow>
+                      <NextLink
+                        href={{ query: { [PAGE_QUERY_PARAM]: page + 1 } }}
+                        shallow
+                        // Pagination marker for search engines
+                        rel="next"
+                      >
                         <Button variant="contained" size="large" onClick={onShowMore}>
                           Show more
                         </Button>


### PR DESCRIPTION
This adds the current page number of the Ecosystem page to the search params, also initialising based on the value.