### PR TITLE
Add links to ecosystem page, close filters by default

### DIFF
--- a/src/components/Ecosystem/Projects/SidebarAccordion.tsx
+++ b/src/components/Ecosystem/Projects/SidebarAccordion.tsx
@@ -25,7 +25,7 @@ export const SidebarAccordion = ({
   onChange: (item: string, checked: boolean) => void
 }) => {
   return (
-    <Accordion defaultExpanded className={css.accordion}>
+    <Accordion className={css.accordion}>
       <AccordionSummary expandIcon={<ChevronDownIcon />}>
         <Typography variant="caption" color="text.primary">
           {title}

--- a/src/content/ecosystem.json
+++ b/src/content/ecosystem.json
@@ -17,7 +17,7 @@
           "alt": "Code block"
         },
         "link": {
-          "href": "#"
+          "href": "https://docs.safe.global/learn/safe-core"
         }
       },
       {
@@ -37,7 +37,7 @@
           "alt": "Arrow angled"
         },
         "link": {
-          "href": "#"
+          "href": "https://ecosystem-careers.safe.global"
         }
       }
     ],
@@ -49,12 +49,12 @@
     "buttons": [
       {
         "text": "Documentation",
-        "href": "#",
+        "href": "https://docs.safe.global/learn/safe-core",
         "variant": "button"
       },
       {
-        "text": "Another Link",
-        "href": "#",
+        "text": "Get in touch",
+        "href": "https://ecosystem-contact.safe.global",
         "variant": "link"
       }
     ],
@@ -77,7 +77,7 @@
       },
       {
         "title": "Extend Safe Functionality",
-        "text": "Add new features to the Safe protocol by building a module, or further secure your transactions by creating a guard. Contact us for more info",
+        "text": "Add new features to the Safe protocol by building a module, or further secure your transactions by creating a guard.",
         "image": {
           "src": "/images/arrow-out-icon.svg",
           "alt": "Arrow angled"


### PR DESCRIPTION
## What it solves

Part of #176 

Adds links according to this [thread](https://5afe.slack.com/archives/C04LENM73JQ/p1683792898777299?thread_ts=1683709710.191559&cid=C04LENM73JQ)
Note that 2 of the links are not configured yet but should be ready next week

## How to test

1. Open `/ecosystem`
2. Observe all links are set (no more #)
3. Observe the filters are closed by default