### PR TITLE
fix: Support trailing slashes for all pages

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -11,6 +11,7 @@ const nextConfig = {
       transform: '@mui/material/{{member}}',
     },
   },
+  trailingSlash: true,
   webpack(config) {
     config.module.rules.push({
       test: /\.svg$/i,


### PR DESCRIPTION
## What it solves

Supports trailing slashes for all pages e.g. opening `/cla` results in `/cla/`

## How to test

1. Open the homepage
2. Navigate to a few pages
3. Observe a trailing slash in the URL
4. Navigate to pages without a trailing slash via URL
5. Observe seeing the page