### PR TITLE
Chore: deploy all PR branches to dev

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,6 @@ on:
 
   push:
     branches:
-      - dev
       - main
 
 jobs:
@@ -37,16 +36,31 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
 
-      # Staging
+      # Deploy the main branch to staging
       - name: Deploy to the staging S3
         if: github.ref == 'refs/heads/main'
         env:
           BUCKET: s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/current
         run: bash ./scripts/github/s3_upload.sh
 
-      # Dev
+      # Deploy all other branches to dev
       - name: Deploy to the dev S3
-        if: github.ref == 'refs/heads/dev'
+        if: github.ref != 'refs/heads/main'
         env:
           BUCKET: s3://${{ secrets.AWS_DEVELOPMENT_BUCKET_NAME }}
         run: bash ./scripts/github/s3_upload.sh
+
+      # Comment
+      - name: Post a deployment link in the PR
+        if: always() && github.event.number
+        uses: mshick/add-pr-comment@v2
+        with:
+          message-id: praul
+          message: |
+            ## Branch preview
+            ✅  Deployed to dev:
+
+            https://safe-web-landing.dev.5afe.dev
+          message-failure: |
+            ## Branch preview
+            ❌  Deploy failed!


### PR DESCRIPTION
We don't have per-branch deployments, so let's at least deploy all branches to dev. If multiple PRs are open at the same time, they will overwrite each other but that's OK.