### PR TITLE
feat: hook to ease scroll to an element

### DIFF
--- a/src/components/Core/Masthead/index.tsx
+++ b/src/components/Core/Masthead/index.tsx
@@ -10,7 +10,7 @@ import Link from 'next/link'
 
 export const Masthead = ({ title, buttons, caption, image }: BaseBlock): ReactElement => {
   return (
-    <Container className={layoutCss.containerShort}>
+    <Container className={layoutCss.containerShort} id="masthead">
       <div className={css.container}>
         <Grid container spacing={{ xs: '90px', sm: '30px' }} justifyContent="space-between">
           <Grid item xs={12} md={7} lg={8}>

--- a/src/components/Core/index.tsx
+++ b/src/components/Core/index.tsx
@@ -1,7 +1,10 @@
 import type { ReactElement } from 'react'
 import PageContent from '@/components/common/PageContent'
 import coreContent from '@/content/core.json'
+import { useDelayedScrollAnimation } from '@/hooks/useDelayedScrollAnimation'
 
 export const Core = (): ReactElement => {
+  useDelayedScrollAnimation('masthead', 1000, 500, 0.2)
+
   return <PageContent content={coreContent} path="core.json" />
 }

--- a/src/hooks/useDelayedScrollAnimation.ts
+++ b/src/hooks/useDelayedScrollAnimation.ts
@@ -1,0 +1,59 @@
+import { useEffect } from 'react'
+
+// Ease-out easing function
+function easeOut(t: number) {
+  return 1 - Math.pow(1 - t, 3)
+}
+
+/**
+ * Custom React hook for triggering a delayed scroll animation with easing.
+ *
+ * @param {string} elementId - The ID of the target element to scroll to.
+ * @param {number} duration - Duration of the scroll animation in milliseconds.
+ * @param {number} delay - Delay in milliseconds before starting the scroll animation.
+ * @param {number} factor - The viewport factor to subtract to the target element top.
+ *
+ * @returns {void}
+ */
+export const useDelayedScrollAnimation = (elementId: string, duration: number, delay: number, factor: number) => {
+  useEffect(() => {
+    if (window === undefined) return
+
+    // Set a timeout to trigger the scroll animation after the delay
+    const timeoutId = setTimeout(() => {
+      const startTime = performance.now()
+      const startScrollY = window.scrollY
+      const targetElement = document.getElementById(elementId)
+
+      if (!targetElement) {
+        console.error(`Target element ${elementId} not found.`)
+        return
+      }
+
+      // Target scroll position is the target element top minus the viewport factor
+      const targetScrollY = targetElement.getBoundingClientRect().top - window.innerHeight * factor
+
+      // Define a function for the scroll animation
+      function animateScroll(currentTime: number) {
+        const elapsedTime = currentTime - startTime
+        if (elapsedTime < duration) {
+          const scrollProgress = elapsedTime / duration
+          const easedProgress = easeOut(scrollProgress)
+
+          const scrollDelta = targetScrollY * easedProgress
+          const newScrollY = startScrollY + scrollDelta
+
+          window.scrollTo(0, newScrollY)
+          requestAnimationFrame(animateScroll)
+        } else {
+          window.scrollTo(0, targetScrollY)
+        }
+      }
+
+      // Start the animation
+      requestAnimationFrame(animateScroll)
+    }, delay)
+
+    return () => clearTimeout(timeoutId)
+  }, [delay, duration, elementId, factor])
+}


### PR DESCRIPTION
## What it solves

Resolves #227 

## How this PR fixes it

When opening the Core page, smoothly scrolls to the masthead section.
The target scroll position, ease and duration are reviewed by the design team.

