### PR TITLE
fix: Homepage title

### DIFF
--- a/src/content/ecosystem.json
+++ b/src/content/ecosystem.json
@@ -1,6 +1,7 @@
 [
   {
     "pageTitle": "Safe – Ecosystem",
+    "description": "Explore the Safe Ecosystem",
     "image": "https://safe.global/images/ecosystem-image.jpg",
     "component": "common/MetaTags"
   },

--- a/src/content/home.json
+++ b/src/content/home.json
@@ -1,6 +1,6 @@
 [
   {
-    "pageTitle": "Safe – Previously Gnosis Safe – Crypto wallet, web3 account abstraction developer stack",
+    "pageTitle": "Safe – Previously Gnosis Safe",
     "component": "common/MetaTags"
   },
   {

--- a/src/content/wallet.json
+++ b/src/content/wallet.json
@@ -1,6 +1,7 @@
 [
   {
-    "pageTitle": "Safe Wallet – Self-custodial multisig wallet for the Ethereum ecosystem",
+    "pageTitle": "Safe Wallet",
+    "description": "Self-custodial multisig wallet for the Ethereum ecosystem",
     "component": "common/MetaTags"
   },
   {
@@ -231,10 +232,7 @@
       },
       {
         "label": "Allow push notifications",
-        "description": [
-          "Track movement of your assets and transactions",
-          "Get alerts"
-        ],
+        "description": ["Track movement of your assets and transactions", "Get alerts"],
         "state": "active"
       },
       {


### PR DESCRIPTION
## What it solves

Resolves Google search results in mobile is displaying the wrong homepage title
![Screenshot 2023-09-21 at 10 43 43](https://github.com/safe-global/safe-homepage/assets/32431609/e4b3cb38-493b-4fea-8278-bc2fbd3acb66)


## How this PR fixes it

1. Reducing the Homepage title length will keep Google from rewriting the page title
2. Adjusted the Wallet and Ecosystem descriptions that are also being rewritten.
