### PR TITLE
feat: rich text

### DIFF
--- a/src/components/Home/types.d.ts
+++ b/src/components/Home/types.d.ts
@@ -1,9 +1,12 @@
 import type { DetailedHTMLProps, ImgHTMLAttributes } from 'react'
 import type { ButtonProps } from '@mui/material'
 
+type RichTextVariant = 'text' | 'link'
+
 type BaseBlock = {
   title: string | JSX.Element
   text: string | JSX.Element
+  richText?: (Pick<BaseBlock, 'text' | 'link'> & { variant: RichTextVariant })[]
   caption?: string
   link?: Link
   buttons?: Button[]

--- a/src/components/Home/types.d.ts
+++ b/src/components/Home/types.d.ts
@@ -1,12 +1,11 @@
 import type { DetailedHTMLProps, ImgHTMLAttributes } from 'react'
 import type { ButtonProps } from '@mui/material'
-
-type RichTextVariant = 'text' | 'link'
+import type { richTextVariants } from '@/components/common/RichText'
 
 type BaseBlock = {
   title: string | JSX.Element
   text: string | JSX.Element
-  richText?: (Pick<BaseBlock, 'text' | 'link'> & { variant: RichTextVariant })[]
+  richText?: RichTextType[]
   caption?: string
   link?: Link
   buttons?: Button[]
@@ -25,3 +24,6 @@ type Button = {
   variant: 'button' | 'link'
   color?: ButtonProps['color']
 }
+
+type RichTextVariantType = keyof typeof richTextVariants
+type RichTextType = Pick<BaseBlock, RichTextVariantType> & { variant: RichTextVariantType }

--- a/src/components/common/ParallaxText/index.tsx
+++ b/src/components/common/ParallaxText/index.tsx
@@ -6,6 +6,7 @@ import type { BaseBlock } from '@/components/Home/types'
 import Stepper, { type StepsType } from '@/components/Wallet/Stepper'
 import clsx from 'clsx'
 import ButtonsWrapper from '@/components/common/ButtonsWrapper'
+import RichText from '@/components/common/RichText'
 
 export type ParallaxTextProps = BaseBlock & {
   variant: 'image-text' | 'text-image'
@@ -43,19 +44,7 @@ const ParallaxText = ({
           )}
           <Typography variant="h2">{title}</Typography>
           {text ? <Typography>{text}</Typography> : undefined}
-          {richText ? (
-            <Typography className={css.richText}>
-              {richText.map((item, index) =>
-                item.variant === 'text' ? (
-                  item.text
-                ) : item.variant === 'link' && item.link ? (
-                  <a key={index} href={item.link.href} target="_blank" rel="noreferrer">
-                    {item.link.title}
-                  </a>
-                ) : undefined,
-              )}
-            </Typography>
-          ) : undefined}
+          <RichText richText={richText} />
           {steps && <Stepper steps={steps} />}
           <ButtonsWrapper buttons={buttons} />
         </Grid>

--- a/src/components/common/ParallaxText/index.tsx
+++ b/src/components/common/ParallaxText/index.tsx
@@ -15,6 +15,7 @@ export type ParallaxTextProps = BaseBlock & {
 const ParallaxText = ({
   title,
   text,
+  richText,
   buttons,
   steps,
   caption,
@@ -41,7 +42,20 @@ const ParallaxText = ({
             </Typography>
           )}
           <Typography variant="h2">{title}</Typography>
-          <Typography>{text}</Typography>
+          {text ? <Typography>{text}</Typography> : undefined}
+          {richText ? (
+            <Typography className={css.richText}>
+              {richText.map((item, index) =>
+                item.variant === 'text' ? (
+                  item.text
+                ) : item.variant === 'link' && item.link ? (
+                  <a key={index} href={item.link.href} target="_blank" rel="noreferrer">
+                    {item.link.title}
+                  </a>
+                ) : undefined,
+              )}
+            </Typography>
+          ) : undefined}
           {steps && <Stepper steps={steps} />}
           <ButtonsWrapper buttons={buttons} />
         </Grid>

--- a/src/components/common/ParallaxText/styles.module.css
+++ b/src/components/common/ParallaxText/styles.module.css
@@ -1,8 +1,3 @@
-.richText a {
-  text-decoration: underline;
-  color: var(--mui-palette-primary-main);
-}
-
 .textFirst,
 .imageFirst {
   flex-direction: column-reverse;

--- a/src/components/common/ParallaxText/styles.module.css
+++ b/src/components/common/ParallaxText/styles.module.css
@@ -1,3 +1,8 @@
+.richText a {
+  text-decoration: underline;
+  color: var(--mui-palette-primary-main);
+}
+
 .textFirst,
 .imageFirst {
   flex-direction: column-reverse;

--- a/src/components/common/RichText/index.tsx
+++ b/src/components/common/RichText/index.tsx
@@ -1,0 +1,39 @@
+import { Typography } from '@mui/material'
+import { type BaseBlock, type RichTextType } from '@/components/Home/types'
+import css from './styles.module.css'
+
+export const richTextVariants = {
+  text: 'text',
+  link: 'link',
+} as const
+
+const renderRichTextItem = (item: RichTextType) => {
+  switch (item.variant) {
+    case richTextVariants.text:
+      return item.text
+
+    case richTextVariants.link:
+      return (
+        item.link && (
+          <a href={item.link.href} target="_blank" rel="noreferrer">
+            {item.link.title}
+          </a>
+        )
+      )
+
+    default:
+      return undefined
+  }
+}
+
+type RichTextProps = {
+  richText: BaseBlock['richText']
+}
+
+const RichText = ({ richText }: RichTextProps) => {
+  if (!richText) return null
+
+  return <Typography className={css.richText}>{richText.map(renderRichTextItem)}</Typography>
+}
+
+export default RichText

--- a/src/components/common/RichText/styles.module.css
+++ b/src/components/common/RichText/styles.module.css
@@ -1,0 +1,4 @@
+.richText a {
+  text-decoration: underline;
+  color: var(--mui-palette-primary-main);
+}

--- a/src/content/governance.json
+++ b/src/content/governance.json
@@ -170,7 +170,23 @@
     "variant": "image-text",
     "caption": "How we work",
     "title": "<i>Safe</i> governance process",
-    "text": "The current governance process is a series of phases involving ideation, discussion, and voting. A <b>new governance framework</b> is in the works.",
+    "richText": [
+      {
+        "variant": "text",
+        "text": "The current governance process is a series of phases involving ideation, discussion, and voting. A "
+      },
+      {
+        "variant": "link",
+        "link": {
+          "title": "new governance framework",
+          "href": "https://forum.safe.global/t/sep-7-governance-framework/3711"
+        }
+      },
+      {
+        "variant": "text",
+        "text": " was successfully voted in by SafeDAO on Oct 20, 2023."
+      }
+    ],
     "buttons": [
       {
         "text": "Read more",

--- a/src/content/governance.json
+++ b/src/content/governance.json
@@ -173,7 +173,7 @@
     "richText": [
       {
         "variant": "text",
-        "text": "The current governance process is a series of phases involving ideation, discussion, and voting. A "
+        "text": "SafeDAO's governance is based on an iterative and dynamic structure. Check out the "
       },
       {
         "variant": "link",
@@ -184,7 +184,7 @@
       },
       {
         "variant": "text",
-        "text": " was successfully voted in by SafeDAO on Oct 20, 2023."
+        "text": " outlining the key stakeholders, the dynamic governance approach and the governance process with its series of phases leading to a vote."
       }
     ],
     "buttons": [


### PR DESCRIPTION
## What it solves

Adds `richText` to the BaseBlock type. One step closer to how CMS store rich text.
Solves the need to have links in between text blocks.

## Screenshot

![Screenshot 2023-10-27 at 15 34 00](https://github.com/safe-global/safe-homepage/assets/32431609/4851a043-4c8a-4911-9357-f72ecee43fea)
