### PR TITLE
feat: Track "Social Login" campaign

### DIFF
--- a/src/components/Campaign/Faq/index.tsx
+++ b/src/components/Campaign/Faq/index.tsx
@@ -1,3 +1,4 @@
+import ReactGA from 'react-ga4'
 import {
   Accordion,
   AccordionDetails,
@@ -28,6 +29,7 @@ const Faq = (props: FaqEntry) => {
   const faqData = items.filter(isEntryTypeFaqEntry).map((item) => ({
     question: item.fields.question,
     answer: item.fields.answer,
+    slug: item.fields.slug,
   }))
 
   return (
@@ -64,7 +66,16 @@ const Faq = (props: FaqEntry) => {
                   disableGutters
                   square
                 >
-                  <AccordionSummary expandIcon={openMap?.[index] ? <MinusIcon /> : <PlusIcon />}>
+                  <AccordionSummary
+                    expandIcon={openMap?.[index] ? <MinusIcon /> : <PlusIcon />}
+                    onClick={() => {
+                      ReactGA.event({
+                        category: 'social-login-campaign',
+                        action: 'faq-question-click',
+                        label: `${item.slug}`,
+                      })
+                    }}
+                  >
                     <Typography variant="h4">{item.question}</Typography>
                   </AccordionSummary>
                   <AccordionDetails>

--- a/src/components/Campaign/Faq/index.tsx
+++ b/src/components/Campaign/Faq/index.tsx
@@ -1,4 +1,3 @@
-import ReactGA from 'react-ga4'
 import {
   Accordion,
   AccordionDetails,
@@ -18,6 +17,8 @@ import css from './styles.module.css'
 import BackgroundImage from '@/public/images/Campaigns/faq-bg.png'
 import Image from 'next/image'
 import { isEntryTypeFaqEntry } from '@/lib/typeGuards'
+import { trackEvent } from '@/services/analytics/trackEvent'
+import { SOCIAL_LOGIN_EVENTS } from '@/services/analytics/events/socialLogin'
 
 type FaqEntry = Entry<TypeFaqSkeleton, undefined, string>
 
@@ -69,11 +70,12 @@ const Faq = (props: FaqEntry) => {
                   <AccordionSummary
                     expandIcon={openMap?.[index] ? <MinusIcon /> : <PlusIcon />}
                     onClick={() => {
-                      ReactGA.event({
-                        category: 'social-login-campaign',
-                        action: 'faq-question-click',
-                        label: `${item.slug}`,
-                      })
+                      // fire event only when accordion is expanded
+                      !openMap?.[index] &&
+                        trackEvent({
+                          ...SOCIAL_LOGIN_EVENTS.FAQ_QUESTION_EXPAND,
+                          label: `${item.slug}`,
+                        })
                     }}
                   >
                     <Typography variant="h4">{item.question}</Typography>

--- a/src/components/Campaign/Hero/index.tsx
+++ b/src/components/Campaign/Hero/index.tsx
@@ -1,4 +1,3 @@
-import ReactGA from 'react-ga4'
 import { Button, Chip, Container, Grid, Typography } from '@mui/material'
 import Link from 'next/link'
 import css from './styles.module.css'
@@ -8,6 +7,8 @@ import { isAsset, isEntryTypeButton } from '@/lib/typeGuards'
 import layoutCss from '@/components/common/styles.module.css'
 import RichText from '@/components/Campaign/RichText'
 import { createImageData } from '@/lib/createImageData'
+import { SOCIAL_LOGIN_EVENTS } from '@/services/analytics/events/socialLogin'
+import { trackEvent } from '@/services/analytics/trackEvent'
 
 type HeroEntry = Entry<TypeHeroSkeleton, undefined, string>
 
@@ -47,13 +48,12 @@ const Hero = (props: HeroEntry) => {
               <Button
                 variant="contained"
                 size="large"
-                onClick={() => {
-                  ReactGA.event({
-                    category: 'social-login-campaign',
-                    action: 'faq-question-click',
+                onClick={() =>
+                  trackEvent({
+                    ...SOCIAL_LOGIN_EVENTS.START_NOW_CLICK,
                     label: 'hero',
                   })
-                }}
+                }
               >
                 {button.fields.btnCopy}
               </Button>

--- a/src/components/Campaign/Hero/index.tsx
+++ b/src/components/Campaign/Hero/index.tsx
@@ -1,3 +1,4 @@
+import ReactGA from 'react-ga4'
 import { Button, Chip, Container, Grid, Typography } from '@mui/material'
 import Link from 'next/link'
 import css from './styles.module.css'
@@ -43,7 +44,17 @@ const Hero = (props: HeroEntry) => {
 
           {isEntryTypeButton(button) ? (
             <Link href={button.fields.btnHref} target="_blank" rel="noreferrer" passHref>
-              <Button variant="contained" size="large">
+              <Button
+                variant="contained"
+                size="large"
+                onClick={() => {
+                  ReactGA.event({
+                    category: 'social-login-campaign',
+                    action: 'faq-question-click',
+                    label: 'hero',
+                  })
+                }}
+              >
                 {button.fields.btnCopy}
               </Button>
             </Link>

--- a/src/components/Campaign/RoundCardGrid/index.tsx
+++ b/src/components/Campaign/RoundCardGrid/index.tsx
@@ -6,6 +6,8 @@ import type { Entry } from 'contentful'
 import type { TypeRoundCardGridSkeleton } from '@/contentful/types'
 import { isAsset, isEntryTypeButton, isEntryTypeCardGridItem } from '@/lib/typeGuards'
 import layoutCss from '@/components/common/styles.module.css'
+import { trackEvent } from '@/services/analytics/trackEvent'
+import { SOCIAL_LOGIN_EVENTS } from '@/services/analytics/events/socialLogin'
 
 type RoundCardType = {
   title: string
@@ -44,9 +46,16 @@ const RoundCardGrid = (props: RoundCardGridEntry) => {
       : undefined,
   }))
 
+  const handleCtaClick = () => {
+    trackEvent({
+      ...SOCIAL_LOGIN_EVENTS.START_NOW_CLICK,
+      label: 'round-card-grid',
+    })
+  }
+
   return (
     <Container className={layoutCss.containerMedium}>
-      <HeaderCTA title={title} text={text} link={headerLink} />
+      <HeaderCTA title={title} text={text} link={headerLink} onClick={handleCtaClick} />
 
       <Grid container className={css.gridContainer} spacing={4}>
         <div className={css.spot} />

--- a/src/components/Campaign/TextBlockBanner/index.tsx
+++ b/src/components/Campaign/TextBlockBanner/index.tsx
@@ -1,4 +1,3 @@
-import ReactGA from 'react-ga4'
 import { Button, Container, Typography } from '@mui/material'
 import React from 'react'
 import layoutCss from '@/components/common/styles.module.css'
@@ -8,6 +7,8 @@ import type { Entry } from 'contentful'
 import Image from 'next/image'
 import Link from 'next/link'
 import type { TypeTextBlockBannerSkeleton } from '@/contentful/types'
+import { trackEvent } from '@/services/analytics/trackEvent'
+import { SOCIAL_LOGIN_EVENTS } from '@/services/analytics/events/socialLogin'
 
 type TextBlockBannerEntry = Entry<TypeTextBlockBannerSkeleton, undefined, string>
 
@@ -37,9 +38,8 @@ const TextBlockBanner = (props: TextBlockBannerEntry) => {
                 size="large"
                 color="secondary"
                 onClick={() => {
-                  ReactGA.event({
-                    category: 'social-login-campaign',
-                    action: 'start-now-click',
+                  trackEvent({
+                    ...SOCIAL_LOGIN_EVENTS.START_NOW_CLICK,
                     label: 'banner',
                   })
                 }}

--- a/src/components/Campaign/TextBlockBanner/index.tsx
+++ b/src/components/Campaign/TextBlockBanner/index.tsx
@@ -1,3 +1,4 @@
+import ReactGA from 'react-ga4'
 import { Button, Container, Typography } from '@mui/material'
 import React from 'react'
 import layoutCss from '@/components/common/styles.module.css'
@@ -31,7 +32,18 @@ const TextBlockBanner = (props: TextBlockBannerEntry) => {
 
           {isEntryTypeButton(button) ? (
             <Link href={button.fields.btnHref} target="_blank" rel="noreferrer" passHref>
-              <Button variant="contained" size="large" color="secondary">
+              <Button
+                variant="contained"
+                size="large"
+                color="secondary"
+                onClick={() => {
+                  ReactGA.event({
+                    category: 'social-login-campaign',
+                    action: 'start-now-click',
+                    label: 'banner',
+                  })
+                }}
+              >
                 {button.fields.btnCopy}
               </Button>
             </Link>

--- a/src/components/Campaign/TextBlockCentered/index.tsx
+++ b/src/components/Campaign/TextBlockCentered/index.tsx
@@ -1,4 +1,3 @@
-import ReactGA from 'react-ga4'
 import React from 'react'
 import { Button, Container, Typography } from '@mui/material'
 import Image from 'next/image'
@@ -8,6 +7,8 @@ import layoutCss from '@/components/common/styles.module.css'
 import type { Entry } from 'contentful'
 import type { TypeTextBlockCenteredSkeleton } from '@/contentful/types'
 import { isAsset, isEntryTypeButton } from '@/lib/typeGuards'
+import { trackEvent } from '@/services/analytics/trackEvent'
+import { SOCIAL_LOGIN_EVENTS } from '@/services/analytics/events/socialLogin'
 
 type TextBlockCenteredEntry = Entry<TypeTextBlockCenteredSkeleton, undefined, string>
 
@@ -36,13 +37,12 @@ const TextBlockCentered = (props: TextBlockCenteredEntry) => {
             <Button
               variant="contained"
               size="large"
-              onClick={() => {
-                ReactGA.event({
-                  category: 'social-login-campaign',
-                  action: 'start-now-click',
+              onClick={() =>
+                trackEvent({
+                  ...SOCIAL_LOGIN_EVENTS.START_NOW_CLICK,
                   label: 'centered-block',
                 })
-              }}
+              }
             >
               {button.fields.btnCopy}
             </Button>

--- a/src/components/Campaign/TextBlockCentered/index.tsx
+++ b/src/components/Campaign/TextBlockCentered/index.tsx
@@ -1,3 +1,4 @@
+import ReactGA from 'react-ga4'
 import React from 'react'
 import { Button, Container, Typography } from '@mui/material'
 import Image from 'next/image'
@@ -32,7 +33,17 @@ const TextBlockCentered = (props: TextBlockCenteredEntry) => {
 
         {isEntryTypeButton(button) ? (
           <Link href={button.fields.btnHref} target="_blank" rel="noreferrer" passHref>
-            <Button variant="contained" size="large">
+            <Button
+              variant="contained"
+              size="large"
+              onClick={() => {
+                ReactGA.event({
+                  category: 'social-login-campaign',
+                  action: 'start-now-click',
+                  label: 'centered-block',
+                })
+              }}
+            >
               {button.fields.btnCopy}
             </Button>
           </Link>

--- a/src/components/common/HeaderCTA/index.tsx
+++ b/src/components/common/HeaderCTA/index.tsx
@@ -1,3 +1,4 @@
+import ReactGA from 'react-ga4'
 import type { BaseBlock } from '@/components/Home/types'
 import LinkButton from '@/components/common/LinkButton'
 import { Grid, Typography } from '@mui/material'
@@ -18,7 +19,18 @@ const HeaderCTA = (props: BaseBlock & { bigTitle?: boolean }) => {
       {props.link && (
         <Grid item xs={12} md={4} className={`${css.linkButton} ${!props.bigTitle && css.alignEnd}`}>
           <Link href={props.link.href} target="_blank" rel="noreferrer" passHref>
-            <LinkButton className={css.shortPadding}>{props.link.title}</LinkButton>
+            <LinkButton
+              className={css.shortPadding}
+              onClick={() => {
+                ReactGA.event({
+                  category: 'social-login-campaign',
+                  action: 'start-now-click',
+                  label: 'round-card-grid',
+                })
+              }}
+            >
+              {props.link.title}
+            </LinkButton>
           </Link>
         </Grid>
       )}

--- a/src/components/common/HeaderCTA/index.tsx
+++ b/src/components/common/HeaderCTA/index.tsx
@@ -1,11 +1,10 @@
-import ReactGA from 'react-ga4'
 import type { BaseBlock } from '@/components/Home/types'
 import LinkButton from '@/components/common/LinkButton'
 import { Grid, Typography } from '@mui/material'
 import Link from 'next/link'
 import css from './styles.module.css'
 
-const HeaderCTA = (props: BaseBlock & { bigTitle?: boolean }) => {
+const HeaderCTA = (props: BaseBlock & { bigTitle?: boolean; onClick?: () => void }) => {
   return (
     <Grid container mb={{ sm: 5, md: 7 }}>
       <Grid item xs={12} md={!props.bigTitle ? 8 : undefined}>
@@ -19,16 +18,7 @@ const HeaderCTA = (props: BaseBlock & { bigTitle?: boolean }) => {
       {props.link && (
         <Grid item xs={12} md={4} className={`${css.linkButton} ${!props.bigTitle && css.alignEnd}`}>
           <Link href={props.link.href} target="_blank" rel="noreferrer" passHref>
-            <LinkButton
-              className={css.shortPadding}
-              onClick={() => {
-                ReactGA.event({
-                  category: 'social-login-campaign',
-                  action: 'start-now-click',
-                  label: 'round-card-grid',
-                })
-              }}
-            >
+            <LinkButton className={css.shortPadding} onClick={props.onClick}>
               {props.link.title}
             </LinkButton>
           </Link>

--- a/src/contentful/types/TypeFaqEntry.ts
+++ b/src/contentful/types/TypeFaqEntry.ts
@@ -3,6 +3,7 @@ import type { ChainModifiers, Entry, EntryFieldTypes, EntrySkeletonType, LocaleC
 export interface TypeFaqEntryFields {
   question: EntryFieldTypes.Symbol
   answer: EntryFieldTypes.Text
+  slug?: EntryFieldTypes.Symbol
 }
 
 export type TypeFaqEntrySkeleton = EntrySkeletonType<TypeFaqEntryFields, 'faqEntry'>

--- a/src/services/analytics/events/socialLogin.ts
+++ b/src/services/analytics/events/socialLogin.ts
@@ -1,0 +1,12 @@
+const SOCIAL_LOGIN_CATEGORY = 'social-login-campaign'
+
+export const SOCIAL_LOGIN_EVENTS = {
+  START_NOW_CLICK: {
+    category: SOCIAL_LOGIN_CATEGORY,
+    action: 'start-now-click',
+  },
+  FAQ_QUESTION_EXPAND: {
+    category: SOCIAL_LOGIN_CATEGORY,
+    action: 'faq-question-expand',
+  },
+}

--- a/src/services/analytics/trackEvent.ts
+++ b/src/services/analytics/trackEvent.ts
@@ -1,0 +1,6 @@
+import ReactGA from 'react-ga4'
+import type { UaEventOptions } from 'react-ga4/types/ga4'
+
+export const trackEvent = (eventData: UaEventOptions | string) => {
+  ReactGA.event(eventData)
+}

--- a/src/services/analytics/trackEvent.ts
+++ b/src/services/analytics/trackEvent.ts
@@ -1,6 +1,6 @@
 import ReactGA from 'react-ga4'
 import type { UaEventOptions } from 'react-ga4/types/ga4'
 
-export const trackEvent = (eventData: UaEventOptions | string) => {
+export const trackEvent = (eventData: UaEventOptions) => {
   ReactGA.event(eventData)
 }


### PR DESCRIPTION
## What it solves

Adds tracking to the "Social Login" campaign page according to the shared [doc](https://www.notion.so/safe-global/Tracking-events-Social-login-campaign-page-52c473bee00442e38f82159c1c20a8b9#e5705ffaff5242ae890ffac27a3e5735) 

## How this PR fixes it
- Creates an util function to fire a GA4 event
- Uses the tracking function when clicking the elements defined in the documentation

## Notes
I could only test the events were being received in our analytics dashboard by modifying `useGa.ts` locally. This hook initializes ReactGA4.