### PR TITLE
chore: do not index staging and dev deployments

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: ./.github/workflows/build
         with:
           secrets: ${{ toJSON(secrets) }}
-          is-production: true
+          is-production: ${{ true }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,6 @@ jobs:
       - uses: ./.github/workflows/build
         with:
           secrets: ${{ toJSON(secrets) }}
-          is-production: false
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v3

--- a/src/components/common/MetaTags/index.tsx
+++ b/src/components/common/MetaTags/index.tsx
@@ -1,3 +1,4 @@
+import { IS_PRODUCTION } from '@/config/constants'
 import Head from 'next/head'
 
 const defaultMetaTags = {
@@ -27,6 +28,8 @@ const MetaTags = (props: Partial<typeof defaultMetaTags>) => {
       <meta name="twitter:title" content={seo.pageTitle} />
       <meta name="twitter:description" content={seo.description} />
       <meta name="twitter:image" content={seo.image} />
+
+      {!IS_PRODUCTION && <meta name="robots" content="none" />}
     </Head>
   )
 }


### PR DESCRIPTION
Instruct search engine crawlers not to index deployments other that PRODUCTION.
Having `5afe.dev` pages indexed in search engines damages our SEO performance.