### PR TITLE
chore: change protocol URL

### DIFF
--- a/src/content/core.json
+++ b/src/content/core.json
@@ -72,7 +72,7 @@
         "text": "Discover, integrate and build on Safe’s robust and battle-tested smart contract account standard and programmable modules.",
         "link": {
           "title": "",
-          "href": "https://docs.safe.global/safe-core-protocol"
+          "href": "https://github.com/5afe/safe-core-protocol"
         }
       }
     ],


### PR DESCRIPTION
## What it solves

Changes the docs Protocol URL by the 5afe GitHub repo


<img width="864" alt="Screenshot 2024-02-14 at 09 22 27" src="https://github.com/safe-global/safe-homepage/assets/32431609/c292b960-7b07-4362-b0e4-5587fe036b20">
