### PR TITLE
fix: display Youtube playlists in RichText

### DIFF
--- a/src/components/Blog/YouTube/index.tsx
+++ b/src/components/Blog/YouTube/index.tsx
@@ -1,17 +1,17 @@
-import { extractYouTubeVideoId } from '@/lib/urlPatterns'
+import { getYoutubeVideoSrc } from '@/lib/urlPatterns'
 import css from './styles.module.css'
 
 const YouTube = ({ url }: { url: string }) => {
-  const videoId = extractYouTubeVideoId(url)
+  const videoSrc = getYoutubeVideoSrc(url)
 
-  if (!videoId) return null
+  if (!videoSrc) return null
 
   return (
     <div className={css.videoResponsive}>
       <iframe
         width="853"
         height="480"
-        src={`https://www.youtube-nocookie.com/embed/${videoId}`}
+        src={videoSrc}
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen"
         title="Embedded YouTube"
       />

--- a/src/lib/__test__/urlPatterns.test.ts
+++ b/src/lib/__test__/urlPatterns.test.ts
@@ -1,4 +1,11 @@
-import { extractLastPathname, extractYouTubeVideoId, isTwitterUrl, isYouTubeUrl } from '@/lib/urlPatterns'
+import {
+  extractLastPathname,
+  extractYouTubePlaylistParams,
+  extractYouTubeVideoId,
+  getYoutubeVideoSrc,
+  isTwitterUrl,
+  isYouTubeUrl,
+} from '@/lib/urlPatterns'
 
 describe('urlPatterns', () => {
   describe('isYouTubeUrl', () => {
@@ -7,8 +14,17 @@ describe('urlPatterns', () => {
       expect(isYouTubeUrl('https://youtu.be/dQw4w9WgXcQ')).toBe(true)
     })
 
+    it('should return true for valid videos from YouTube playlists', () => {
+      expect(isYouTubeUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=PL0knnt70iEZpZ_40NHziZ4u7u9f_OW9p6')).toBe(
+        true,
+      )
+      expect(
+        isYouTubeUrl('https://www.youtube.com/watch?v=VbYPL4SVXZw&list=PL0knnt70iEZry_pACXB4sKGSuZz5XNoOd&index=1'),
+      ).toBe(true)
+    })
+
     it('should return true for valid YouTube playlist URLs', () => {
-      expect(isYouTubeUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=PL3A5849BDE0581B19')).toBe(true)
+      expect(isYouTubeUrl('https://www.youtube.com/playlist?list=PL0knnt70iEZry_pACXB4sKGSuZz5XNoOd')).toBe(true)
     })
 
     it('should return false for invalid YouTube URLs', () => {
@@ -26,6 +42,46 @@ describe('urlPatterns', () => {
     it('should return null for non-YouTube URLs', () => {
       expect(extractYouTubeVideoId('https://www.google.com')).toBe(null)
       expect(extractYouTubeVideoId('https://twitter.com')).toBe(null)
+    })
+  })
+
+  describe('extractYouTubePlaylistParams', () => {
+    it('should extract playlist parameters from URL', () => {
+      const url = 'https://www.youtube.com/playlist?list=PL0knnt70iEZry_pACXB4sKGSuZz5XNoOd&index=3'
+      const params = extractYouTubePlaylistParams(url)
+      expect(params.list).toBe('PL0knnt70iEZry_pACXB4sKGSuZz5XNoOd')
+      expect(params.index).toBe('3')
+    })
+
+    it('should return null for parameters not present in URL', () => {
+      const url = 'https://www.youtube.com/playlist?list=PL0knnt70iEZry_pACXB4sKGSuZz5XNoOd'
+      const params = extractYouTubePlaylistParams(url)
+      expect(params.list).toBe('PL0knnt70iEZry_pACXB4sKGSuZz5XNoOd')
+      expect(params.index).toBeNull()
+    })
+  })
+
+  describe('getYoutubeVideoSrc', () => {
+    test('should return correct video src for a video URL', () => {
+      const url = 'https://www.youtube.com/watch?v=Xe5FcBK9vFw'
+      const src = getYoutubeVideoSrc(url)
+      expect(src).toBe('https://www.youtube-nocookie.com/embed/Xe5FcBK9vFw')
+    })
+
+    test('should return correct video src for a playlist URL with index', () => {
+      const url = 'https://www.youtube.com/playlist?list=PL0knnt70iEZry_pACXB4sKGSuZz5XNoOd&index=0'
+      const src = getYoutubeVideoSrc(url)
+      expect(src).toBe(
+        'https://www.youtube-nocookie.com/embed/videoseries?list=PL0knnt70iEZry_pACXB4sKGSuZz5XNoOd&index=0',
+      )
+    })
+
+    test('should return correct video src for a playlist URL without index', () => {
+      const url = 'https://www.youtube.com/playlist?list=PL0knnt70iEZry_pACXB4sKGSuZz5XNoOd'
+      const src = getYoutubeVideoSrc(url)
+      expect(src).toBe(
+        'https://www.youtube-nocookie.com/embed/videoseries?list=PL0knnt70iEZry_pACXB4sKGSuZz5XNoOd&index=1',
+      )
     })
   })
 

--- a/src/lib/__test__/urlPatterns.test.ts
+++ b/src/lib/__test__/urlPatterns.test.ts
@@ -1,6 +1,6 @@
 import {
   extractLastPathname,
-  extractYouTubePlaylistParams,
+  extractURLSearchParams,
   extractYouTubeVideoId,
   getYoutubeVideoSrc,
   isTwitterUrl,
@@ -45,19 +45,19 @@ describe('urlPatterns', () => {
     })
   })
 
-  describe('extractYouTubePlaylistParams', () => {
-    it('should extract playlist parameters from URL', () => {
+  describe('extractURLSearchParams', () => {
+    it('should extract search parameters from URL', () => {
       const url = 'https://www.youtube.com/playlist?list=PL0knnt70iEZry_pACXB4sKGSuZz5XNoOd&index=3'
-      const params = extractYouTubePlaylistParams(url)
+      const params = extractURLSearchParams(url)
       expect(params.list).toBe('PL0knnt70iEZry_pACXB4sKGSuZz5XNoOd')
       expect(params.index).toBe('3')
     })
 
     it('should return null for parameters not present in URL', () => {
       const url = 'https://www.youtube.com/playlist?list=PL0knnt70iEZry_pACXB4sKGSuZz5XNoOd'
-      const params = extractYouTubePlaylistParams(url)
+      const params = extractURLSearchParams(url)
       expect(params.list).toBe('PL0knnt70iEZry_pACXB4sKGSuZz5XNoOd')
-      expect(params.index).toBeNull()
+      expect(params.index).toBe(undefined)
     })
   })
 

--- a/src/lib/__test__/urlPatterns.test.ts
+++ b/src/lib/__test__/urlPatterns.test.ts
@@ -7,6 +7,10 @@ describe('urlPatterns', () => {
       expect(isYouTubeUrl('https://youtu.be/dQw4w9WgXcQ')).toBe(true)
     })
 
+    it('should return true for valid YouTube playlist URLs', () => {
+      expect(isYouTubeUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=PL3A5849BDE0581B19')).toBe(true)
+    })
+
     it('should return false for invalid YouTube URLs', () => {
       expect(isYouTubeUrl('https://www.google.com')).toBe(false)
       expect(isYouTubeUrl('https://twitter.com')).toBe(false)

--- a/src/lib/urlPatterns.ts
+++ b/src/lib/urlPatterns.ts
@@ -1,5 +1,5 @@
 export function isYouTubeUrl(url: string) {
-  const youtubeRegex = /^(https?:\/\/)?(www\.)?(youtube\.com\/watch\?v=|youtu\.be\/)[\w-]{11}$/
+  const youtubeRegex = /^(https?:\/\/)?(www\.)?(youtube\.com\/watch\?v=|youtu\.be\/)[\w-]{11}(&list=\w+)?$/
   return youtubeRegex.test(url)
 }
 

--- a/src/lib/urlPatterns.ts
+++ b/src/lib/urlPatterns.ts
@@ -1,6 +1,7 @@
 export function isYouTubeUrl(url: string) {
   const youtubeRegex =
     /^(https?:\/\/)?(www\.)?(youtube\.com\/(watch\?v=|playlist\?)|youtu\.be\/)([\w-]{11})?(&?list=[\w]{34})?/
+
   return youtubeRegex.test(url)
 }
 
@@ -11,34 +12,38 @@ export function extractYouTubeVideoId(url: string) {
   // long form
   const urlObj = new URL(url)
   const searchParams = new URLSearchParams(urlObj.search)
+
   return searchParams.get('v')
 }
 
-export function extractYouTubePlaylistParams(url: string) {
-  const urlObj = new URL(url)
-  const searchParams = new URLSearchParams(urlObj.search)
-  return {
-    list: searchParams.get('list'),
-    index: searchParams.get('index'),
-  }
-}
+export const extractURLSearchParams = (url: string) => Object.fromEntries(new URL(url).searchParams.entries())
 
 export const getYoutubeVideoSrc = (url: string) => {
   const videoId = extractYouTubeVideoId(url)
-  const { list, index } = extractYouTubePlaylistParams(url)
+  const { list, index } = extractURLSearchParams(url)
 
-  return `https://www.youtube-nocookie.com/embed/${videoId ? videoId : 'videoseries'}${list ? `?list=${list}` : ''}${
-    !videoId ? `&index=${index ?? 1}` : ''
-  }`
+  const urlObj = new URL(`https://www.youtube-nocookie.com/embed/${videoId ? videoId : 'videoseries'}`)
+
+  if (list) {
+    urlObj.searchParams.set('list', list)
+  }
+
+  if (!videoId) {
+    urlObj.searchParams.set('index', index ?? 1)
+  }
+
+  return urlObj.toString()
 }
 
 export function isTwitterUrl(url: string) {
   const tweeterRegex = /^(https?:\/\/)?(?:www\.)?(twitter\.com\/|x\.com\/)[a-zA-Z0-9_]+\/status\/\d+(\?s=\d+)?$/
+
   return tweeterRegex.test(url)
 }
 
 export function extractLastPathname(url: string) {
   const urlObj = new URL(url)
   const pathnameParts = urlObj.pathname.split('/').filter((part) => part !== '')
+
   return pathnameParts[pathnameParts.length - 1] || ''
 }

--- a/src/lib/urlPatterns.ts
+++ b/src/lib/urlPatterns.ts
@@ -1,5 +1,6 @@
 export function isYouTubeUrl(url: string) {
-  const youtubeRegex = /^(https?:\/\/)?(www\.)?(youtube\.com\/watch\?v=|youtu\.be\/)[\w-]{11}(&list=\w+)?$/
+  const youtubeRegex =
+    /^(https?:\/\/)?(www\.)?(youtube\.com\/(watch\?v=|playlist\?)|youtu\.be\/)([\w-]{11})?(&?list=[\w]{34})?/
   return youtubeRegex.test(url)
 }
 
@@ -11,6 +12,24 @@ export function extractYouTubeVideoId(url: string) {
   const urlObj = new URL(url)
   const searchParams = new URLSearchParams(urlObj.search)
   return searchParams.get('v')
+}
+
+export function extractYouTubePlaylistParams(url: string) {
+  const urlObj = new URL(url)
+  const searchParams = new URLSearchParams(urlObj.search)
+  return {
+    list: searchParams.get('list'),
+    index: searchParams.get('index'),
+  }
+}
+
+export const getYoutubeVideoSrc = (url: string) => {
+  const videoId = extractYouTubeVideoId(url)
+  const { list, index } = extractYouTubePlaylistParams(url)
+
+  return `https://www.youtube-nocookie.com/embed/${videoId ? videoId : 'videoseries'}${list ? `?list=${list}` : ''}${
+    !videoId ? `&index=${index ?? 1}` : ''
+  }`
 }
 
 export function isTwitterUrl(url: string) {


### PR DESCRIPTION
Enhance the `youtubeRegex` to accept playlists.

Can be tested in https://fix_embeded_entry--homepage.review.5afe.dev/blog/safe-conference-for-web3-berlin-2024