### PR TITLE
chore: bump package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "safe-homepage",
   "homepage": "https://github.com/safe-global/safe-homepage",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "scripts": {
     "build": "next build && next export",
     "lint": "tsc && next lint",

--- a/src/components/Blog/BannerForm/styles.module.css
+++ b/src/components/Blog/BannerForm/styles.module.css
@@ -7,6 +7,7 @@
   background-color: #f7f7f7;
   border-radius: 24px;
   color: var(--mui-palette-text-dark);
+  overflow: hidden;
 }
 
 .container iframe {


### PR DESCRIPTION
- small style fix: the overflow of the background image in `/blog` banner
- `v1.4.5`
