### PR TITLE
Pressroom releases

### DIFF
--- a/src/components/Blog/SearchFilterResults/index.tsx
+++ b/src/components/Blog/SearchFilterResults/index.tsx
@@ -1,27 +1,17 @@
 import type { BlogPostEntry } from '@/components/Blog/Post'
 import SearchBar from '@/components/Blog/SearchBar'
 import usePostsSearch from '@/components/Blog/usePostsSearch'
-import { Box, Button, ButtonBase, Grid, IconButton, Typography } from '@mui/material'
-import { type NextRouter, useRouter } from 'next/router'
+import { Box, Grid, Typography } from '@mui/material'
+import { useRouter } from 'next/router'
 import { Fragment, useEffect, useMemo, useState } from 'react'
-import css from './styles.module.css'
-
 import Card from '@/components/Blog/Card'
 import SearchIcon from '@/public/images/search.svg'
 import { SpecificCategoryFilter } from '@/components/Ecosystem/Projects/Projects'
-import NextLink from 'next/link'
-import clsx from 'clsx'
-import CloseIcon from '@/public/images/close.svg'
 import { scrollToElement } from '@/lib/scrollSmooth'
+import ShowMoreButton, { getPage } from '@/components/common/ShowMoreButton'
+import CategoryFilter from '@/components/common/CategoryFilter'
 
 const PAGE_LENGTH = 6
-const PAGE_QUERY_PARAM = 'page'
-
-const getPage = (query: NextRouter['query']): number => {
-  const page = Array.isArray(query[PAGE_QUERY_PARAM]) ? query[PAGE_QUERY_PARAM][0] : query[PAGE_QUERY_PARAM]
-
-  return Number(page) || 1
-}
 
 const SearchFilterResults = ({ allPosts, categories }: { allPosts: BlogPostEntry[]; categories: string[] }) => {
   const [searchQuery, setSearchQuery] = useState('')
@@ -84,35 +74,14 @@ const SearchFilterResults = ({ allPosts, categories }: { allPosts: BlogPostEntry
         </Grid>
       </Grid>
 
-      {/* Category filter buttons */}
-      <Grid container className={css.filterWrapper}>
-        {categories.map((category) => {
-          const isSelected = category === selectedCategory
-
-          return (
-            <Grid item key={category} className={css.filterCard} xs={12} md="auto">
-              <ButtonBase
-                className={clsx(css.filterButton, { [css.selected]: isSelected })}
-                onClick={() => handleToggleCategory(category)}
-              >
-                <Typography>
-                  {category}
-                  {isSelected && (
-                    <IconButton className={css.closeFilter} onClick={() => handleToggleCategory(category)}>
-                      <CloseIcon />
-                    </IconButton>
-                  )}
-                </Typography>
-              </ButtonBase>
-            </Grid>
-          )
-        })}
-      </Grid>
+      <Box mt="40px">
+        <CategoryFilter categories={categories} />
+      </Box>
 
       {visibleResults.length > 0 ? (
         <>
-          <Grid container columnSpacing="30px" rowGap="30px" id="results" className={css.resultsWrapper}>
-            {visibleResults.map((post: any) => (
+          <Grid container columnSpacing="30px" rowGap="30px" id="results" mt="60px">
+            {visibleResults.map((post) => (
               <Grid key={post.fields.slug} item xs={12} md={4}>
                 <Card {...post} />
               </Grid>
@@ -129,21 +98,6 @@ const SearchFilterResults = ({ allPosts, categories }: { allPosts: BlogPostEntry
 }
 
 export default SearchFilterResults
-
-const ShowMoreButton = ({ page }: { page: number }) => (
-  <Box display="flex" justifyContent="center" mt="60px">
-    <NextLink
-      href={{ query: { [PAGE_QUERY_PARAM]: page + 1 } }}
-      shallow
-      // Pagination marker for search engines
-      rel="next"
-    >
-      <Button variant="contained" size="large">
-        Show more
-      </Button>
-    </NextLink>
-  </Box>
-)
 
 const NoResults = ({ query }: { query: string }) => (
   <Box mt="60px" textAlign="center">

--- a/src/components/Blog/SearchFilterResults/index.tsx
+++ b/src/components/Blog/SearchFilterResults/index.tsx
@@ -8,8 +8,9 @@ import Card from '@/components/Blog/Card'
 import SearchIcon from '@/public/images/search.svg'
 import { SpecificCategoryFilter } from '@/components/Ecosystem/Projects/Projects'
 import { scrollToElement } from '@/lib/scrollSmooth'
-import ShowMoreButton, { getPage } from '@/components/common/ShowMoreButton'
+import ShowMoreButton from '@/components/common/ShowMoreButton'
 import CategoryFilter from '@/components/common/CategoryFilter'
+import { getPage } from '@/lib/getPage'
 
 const PAGE_LENGTH = 6
 

--- a/src/components/Ecosystem/Projects/Projects.tsx
+++ b/src/components/Ecosystem/Projects/Projects.tsx
@@ -17,7 +17,6 @@ import clsx from 'clsx'
 import { Fragment, useMemo, useState } from 'react'
 import { useRouter } from 'next/router'
 import NextLink from 'next/link'
-import type { NextRouter } from 'next/router'
 import type { GridProps } from '@mui/material'
 import type { Dispatch, ReactElement, SetStateAction } from 'react'
 
@@ -42,6 +41,7 @@ import { useEcosystemData } from '@/hooks/useEcosystemData'
 import { type BaseBlock } from '@/components/Home/types'
 import Cards from '@/components/Ecosystem/Cards'
 import SearchBar from '@/components/Blog/SearchBar'
+import { getPage, PAGE_QUERY_PARAM } from '@/lib/getPage'
 
 const getUniqueStrings = (entries: string[]) => {
   const uniqueEntries = new Set(entries)
@@ -114,14 +114,6 @@ const GRID_SPACING: GridProps['spacing'] = {
 }
 
 const PAGE_LENGTH = 12
-
-const PAGE_QUERY_PARAM = 'page'
-
-const getPage = (query: NextRouter['query']): number => {
-  const page = Array.isArray(query[PAGE_QUERY_PARAM]) ? query[PAGE_QUERY_PARAM][0] : query[PAGE_QUERY_PARAM]
-
-  return Number(page) || 1
-}
 
 export const Projects = ({ items }: BaseBlock): ReactElement => {
   const [query, setQuery] = useState('')

--- a/src/components/Pressroom/PressReleases/index.tsx
+++ b/src/components/Pressroom/PressReleases/index.tsx
@@ -1,0 +1,66 @@
+import { type BlogPostEntry } from '@/components/Blog/Post'
+import { Box, Grid, Typography } from '@mui/material'
+import React, { useMemo } from 'react'
+import Card from '@/components/Blog/Card'
+import { useRouter } from 'next/router'
+import ShowMoreButton, { getPage } from '@/components/common/ShowMoreButton'
+import SearchIcon from '@/public/images/search.svg'
+import CategoryFilter from '@/components/common/CategoryFilter'
+
+const categories = ['Safe{Core}', 'Safe{Wallet}', 'Safe{DAO}', 'Ecosystem', 'Institutional', 'Internal']
+
+const PAGE_LENGTH = 4
+
+const PressReleases = ({ allPosts }: { allPosts: BlogPostEntry[] }) => {
+  const router = useRouter()
+  const selectedCategory = router.query.category
+  const page = getPage(router.query)
+
+  const filteredPosts = useMemo(() => {
+    return !selectedCategory ? allPosts : allPosts.filter((post) => post.fields.category === selectedCategory)
+  }, [allPosts, selectedCategory])
+
+  const visibleResults = filteredPosts.slice(0, PAGE_LENGTH * page)
+  const shouldShowMoreButton = visibleResults.length < allPosts.length
+
+  return (
+    <>
+      <Typography variant="h2" mt={{ xs: '80px', md: '200px' }}>
+        Press releases
+      </Typography>
+
+      <Grid container columnSpacing="30px" rowGap="30px" mt="60px">
+        {/* Quick filter bar*/}
+        <Grid item xs={12} md={4}>
+          <CategoryFilter categories={categories} />
+        </Grid>
+
+        {/* Press posts */}
+        <Grid item xs={12} md={8}>
+          {visibleResults.length > 0 ? (
+            <>
+              <Grid container columnSpacing="30px" rowGap="30px">
+                {visibleResults.map((post) => (
+                  <Grid key={post.fields.slug} item xs={12} md={6}>
+                    <Card {...post} />
+                  </Grid>
+                ))}
+              </Grid>
+
+              {shouldShowMoreButton && <ShowMoreButton page={page} />}
+            </>
+          ) : (
+            <Box mt="60px" textAlign="center">
+              <SearchIcon />
+              <Typography variant="h4" my={2}>
+                No results found for selected filter
+              </Typography>
+            </Box>
+          )}
+        </Grid>
+      </Grid>
+    </>
+  )
+}
+
+export default PressReleases

--- a/src/components/Pressroom/PressReleases/index.tsx
+++ b/src/components/Pressroom/PressReleases/index.tsx
@@ -3,9 +3,10 @@ import { Box, Grid, Typography } from '@mui/material'
 import React, { useMemo } from 'react'
 import Card from '@/components/Blog/Card'
 import { useRouter } from 'next/router'
-import ShowMoreButton, { getPage } from '@/components/common/ShowMoreButton'
+import ShowMoreButton from '@/components/common/ShowMoreButton'
 import SearchIcon from '@/public/images/search.svg'
 import CategoryFilter from '@/components/common/CategoryFilter'
+import { getPage } from '@/lib/getPage'
 
 const categories = ['Safe{Core}', 'Safe{Wallet}', 'Safe{DAO}', 'Ecosystem', 'Institutional', 'Internal']
 

--- a/src/components/Pressroom/index.tsx
+++ b/src/components/Pressroom/index.tsx
@@ -1,4 +1,5 @@
 import FeaturedPost from '@/components/Blog/FeaturedPost'
+import { type BlogPostEntry } from '@/components/Blog/Post'
 import MetaTags from '@/components/common/MetaTagsContentful'
 import FeaturedVideos from '@/components/Pressroom/FeaturedVideos'
 import Founders from '@/components/Pressroom/Founders'
@@ -7,20 +8,28 @@ import Investors from '@/components/Pressroom/Investors'
 import MediaKit from '@/components/Pressroom/MediaKit'
 import News from '@/components/Pressroom/News'
 import Podcasts from '@/components/Pressroom/Podcasts'
+import PressReleases from '@/components/Pressroom/PressReleases'
 import { type TypePressRoomSkeleton } from '@/contentful/types'
+import { containsTag, PRESS_RELEASE_TAG } from '@/lib/containsTag'
 import { isAsset, isEntryType, isEntryTypeExternalURL, isEntryTypePost } from '@/lib/typeGuards'
 import { Container } from '@mui/material'
 import { type Entry } from 'contentful'
 
 export type PressRoomEntry = Entry<TypePressRoomSkeleton, undefined, string>
 
-const PressRoom = ({ pressRoom }: { pressRoom: PressRoomEntry }) => {
+export type PressRoomProps = {
+  pressRoom: PressRoomEntry
+  allPosts: BlogPostEntry[]
+}
+
+const PressRoom = ({ pressRoom, allPosts }: PressRoomProps) => {
   const { metaTags, featured, investors, news, podcasts, videos } = pressRoom.fields
 
   const investorsList = investors.filter(isAsset)
   const newsList = news.filter(isEntryTypeExternalURL)
   const podcastsList = podcasts.filter(isEntryTypeExternalURL)
   const videosList = videos.filter(isEntryTypeExternalURL)
+  const pressPosts = allPosts.filter((post) => containsTag(post.fields.tags, PRESS_RELEASE_TAG))
 
   return (
     <>
@@ -33,6 +42,7 @@ const PressRoom = ({ pressRoom }: { pressRoom: PressRoomEntry }) => {
         <News news={newsList} />
         <Podcasts podcasts={podcastsList} />
         <FeaturedVideos videos={videosList} />
+        <PressReleases allPosts={pressPosts} />
         <MediaKit />
       </Container>
     </>

--- a/src/components/common/CategoryFilter/index.tsx
+++ b/src/components/common/CategoryFilter/index.tsx
@@ -8,7 +8,7 @@ const CategoryFilter = ({ categories }: { categories: string[] }) => {
   const router = useRouter()
   const selectedCategory = router.query.category
 
-  const handleToggleCategory = (category: string) => () => {
+  const toggleCategory = (category: string) => {
     const queryParams = { ...router.query }
 
     if (queryParams.category === category) {
@@ -30,17 +30,15 @@ const CategoryFilter = ({ categories }: { categories: string[] }) => {
     <Grid container className={css.filterWrapper}>
       {categories.map((category) => {
         const isSelected = category === selectedCategory
+        const handleClick = () => toggleCategory(category)
 
         return (
           <Grid item key={category} className={css.filterCard} xs={12} md="auto">
-            <ButtonBase
-              className={clsx(css.filterButton, { [css.selected]: isSelected })}
-              onClick={handleToggleCategory(category)}
-            >
+            <ButtonBase className={clsx(css.filterButton, { [css.selected]: isSelected })} onClick={handleClick}>
               <Typography>
                 {category}
                 {isSelected && (
-                  <IconButton className={css.closeFilter} onClick={handleToggleCategory(category)}>
+                  <IconButton className={css.closeFilter} onClick={handleClick}>
                     <CloseIcon />
                   </IconButton>
                 )}

--- a/src/components/common/CategoryFilter/index.tsx
+++ b/src/components/common/CategoryFilter/index.tsx
@@ -1,0 +1,55 @@
+import { ButtonBase, Grid, IconButton, Typography } from '@mui/material'
+import { useRouter } from 'next/router'
+import clsx from 'clsx'
+import CloseIcon from '@/public/images/close.svg'
+import css from './styles.module.css'
+
+const CategoryFilter = ({ categories }: { categories: string[] }) => {
+  const router = useRouter()
+  const selectedCategory = router.query.category
+  const handleToggleCategory = (category: string) => {
+    const queryParams = { ...router.query }
+
+    if (queryParams.category === category) {
+      delete queryParams.category
+    } else {
+      queryParams.category = category
+    }
+
+    router.push(
+      {
+        query: queryParams,
+      },
+      undefined,
+      { shallow: true },
+    )
+  }
+
+  return (
+    <Grid container className={css.filterWrapper}>
+      {categories.map((category) => {
+        const isSelected = category === selectedCategory
+
+        return (
+          <Grid item key={category} className={css.filterCard} xs={12} md="auto">
+            <ButtonBase
+              className={clsx(css.filterButton, { [css.selected]: isSelected })}
+              onClick={() => handleToggleCategory(category)}
+            >
+              <Typography>
+                {category}
+                {isSelected && (
+                  <IconButton className={css.closeFilter} onClick={() => handleToggleCategory(category)}>
+                    <CloseIcon />
+                  </IconButton>
+                )}
+              </Typography>
+            </ButtonBase>
+          </Grid>
+        )
+      })}
+    </Grid>
+  )
+}
+
+export default CategoryFilter

--- a/src/components/common/CategoryFilter/index.tsx
+++ b/src/components/common/CategoryFilter/index.tsx
@@ -7,7 +7,8 @@ import css from './styles.module.css'
 const CategoryFilter = ({ categories }: { categories: string[] }) => {
   const router = useRouter()
   const selectedCategory = router.query.category
-  const handleToggleCategory = (category: string) => {
+
+  const handleToggleCategory = (category: string) => () => {
     const queryParams = { ...router.query }
 
     if (queryParams.category === category) {
@@ -34,12 +35,12 @@ const CategoryFilter = ({ categories }: { categories: string[] }) => {
           <Grid item key={category} className={css.filterCard} xs={12} md="auto">
             <ButtonBase
               className={clsx(css.filterButton, { [css.selected]: isSelected })}
-              onClick={() => handleToggleCategory(category)}
+              onClick={handleToggleCategory(category)}
             >
               <Typography>
                 {category}
                 {isSelected && (
-                  <IconButton className={css.closeFilter} onClick={() => handleToggleCategory(category)}>
+                  <IconButton className={css.closeFilter} onClick={handleToggleCategory(category)}>
                     <CloseIcon />
                   </IconButton>
                 )}

--- a/src/components/common/CategoryFilter/styles.module.css
+++ b/src/components/common/CategoryFilter/styles.module.css
@@ -2,7 +2,6 @@
   border-radius: 6px;
   border: 1px solid var(--mui-palette-border-light);
   overflow: hidden;
-  margin-top: 40px;
 }
 
 .filterCard {
@@ -30,10 +29,6 @@
 .filterButton:hover,
 .selected {
   border: 1px solid var(--mui-palette-primary-main);
-}
-
-.resultsWrapper {
-  margin-top: 60px;
 }
 
 .closeFilter {

--- a/src/components/common/ShowMoreButton/index.tsx
+++ b/src/components/common/ShowMoreButton/index.tsx
@@ -1,14 +1,6 @@
+import { PAGE_QUERY_PARAM } from '@/lib/getPage'
 import { Box, Button } from '@mui/material'
-import { type NextRouter } from 'next/router'
 import NextLink from 'next/link'
-
-const PAGE_QUERY_PARAM = 'page'
-
-export const getPage = (query: NextRouter['query']): number => {
-  const page = Array.isArray(query[PAGE_QUERY_PARAM]) ? query[PAGE_QUERY_PARAM][0] : query[PAGE_QUERY_PARAM]
-
-  return Number(page) || 1
-}
 
 const ShowMoreButton = ({ page }: { page: number }) => (
   <Box display="flex" justifyContent="center" mt="60px">

--- a/src/components/common/ShowMoreButton/index.tsx
+++ b/src/components/common/ShowMoreButton/index.tsx
@@ -1,0 +1,28 @@
+import { Box, Button } from '@mui/material'
+import { type NextRouter } from 'next/router'
+import NextLink from 'next/link'
+
+const PAGE_QUERY_PARAM = 'page'
+
+export const getPage = (query: NextRouter['query']): number => {
+  const page = Array.isArray(query[PAGE_QUERY_PARAM]) ? query[PAGE_QUERY_PARAM][0] : query[PAGE_QUERY_PARAM]
+
+  return Number(page) || 1
+}
+
+const ShowMoreButton = ({ page }: { page: number }) => (
+  <Box display="flex" justifyContent="center" mt="60px">
+    <NextLink
+      href={{ query: { [PAGE_QUERY_PARAM]: page + 1 } }}
+      shallow
+      // Pagination marker for search engines
+      rel="next"
+    >
+      <Button variant="contained" size="large">
+        Show more
+      </Button>
+    </NextLink>
+  </Box>
+)
+
+export default ShowMoreButton

--- a/src/lib/__test__/getPage.test.ts
+++ b/src/lib/__test__/getPage.test.ts
@@ -1,0 +1,38 @@
+import { getPage } from '@/lib/getPage'
+import { type NextRouter } from 'next/router'
+
+describe('getPage function', () => {
+  it('should return the page number from the query object when it is a string', () => {
+    const mockQuery: NextRouter['query'] = {
+      page: '3',
+    }
+    const result = getPage(mockQuery)
+
+    expect(result).toEqual(3)
+  })
+
+  it('should return the first element the query object when it is an array of strings', () => {
+    const queryWithArray: NextRouter['query'] = {
+      page: ['5', '10', 'foo'],
+    }
+    const result = getPage(queryWithArray)
+
+    expect(result).toEqual(5)
+  })
+
+  it('should default to 1 when the page number is not found or invalid', () => {
+    const queryWithoutPage: NextRouter['query'] = {}
+    const result = getPage(queryWithoutPage)
+
+    expect(result).toEqual(1)
+  })
+
+  it('should default to 1 when the page number is NaN', () => {
+    const queryWithNaN: NextRouter['query'] = {
+      page: 'abc', // Invalid page parameter
+    }
+    const result = getPage(queryWithNaN)
+
+    expect(result).toEqual(1)
+  })
+})

--- a/src/lib/containsTag.ts
+++ b/src/lib/containsTag.ts
@@ -1,7 +1,7 @@
 import { type TagsType } from '@/components/Blog/Tags'
 import { isEntryTypeTag } from '@/lib/typeGuards'
 
-export const PRESS_RELEASE_TAG = 'Institutional'
+export const PRESS_RELEASE_TAG = 'Press'
 
 export const containsTag = (tags: TagsType, targetTag: string) => {
   return !!tags?.filter(isEntryTypeTag)?.some((item) => item.fields.name === targetTag)

--- a/src/lib/getPage.ts
+++ b/src/lib/getPage.ts
@@ -1,0 +1,15 @@
+import { type NextRouter } from 'next/router'
+
+export const PAGE_QUERY_PARAM = 'page'
+
+/**
+ * Returns the page number from the query object of Next.js router.
+ * If the page number is not found or invalid, it returns 1 as default.
+ * @param {NextRouter['query']} query - The query object from Next.js router.
+ * @returns {number} The page number extracted from the query object.
+ */
+export const getPage = (query: NextRouter['query']): number => {
+  const page = Array.isArray(query[PAGE_QUERY_PARAM]) ? query[PAGE_QUERY_PARAM][0] : query[PAGE_QUERY_PARAM]
+
+  return Number(page) || 1
+}

--- a/src/pages/press.tsx
+++ b/src/pages/press.tsx
@@ -1,12 +1,18 @@
 import client from '@/lib/contentful'
-import PressRoom, { type PressRoomEntry } from '@/components/Pressroom'
-import { type TypePressRoomSkeleton } from '@/contentful/types'
+import PressRoom, { type PressRoomProps } from '@/components/Pressroom'
+import type { TypePressRoomSkeleton, TypePostSkeleton } from '@/contentful/types'
 
-const PressroomPage = (props: { pressRoom: PressRoomEntry }) => {
+const PressroomPage = (props: PressRoomProps) => {
   return <PressRoom {...props} />
 }
 
 export const getStaticProps = async () => {
+  const postsEntries = await client.getEntries<TypePostSkeleton>({
+    content_type: 'post',
+    // order by date, most recent first
+    order: ['-fields.date'],
+  })
+
   const pressRoomEntries = await client.getEntries<TypePressRoomSkeleton>({
     content_type: 'pressRoom',
     include: 3,
@@ -14,15 +20,18 @@ export const getStaticProps = async () => {
 
   const pressRoom = pressRoomEntries.items[0]
 
-  if (!pressRoom) {
+  if (!pressRoom || !postsEntries) {
     return {
       notFound: true,
     }
   }
 
+  postsEntries.items.forEach((item: any) => delete item.fields.relatedPosts)
+
   return {
     props: {
       pressRoom,
+      allPosts: postsEntries.items,
     },
   }
 }


### PR DESCRIPTION
## What it solves
Adds the Press releases section on the Pressroom page
Refactors the quick categories filter to its own component in the `/common` folder

## Screenshots
![Screenshot 2024-03-25 at 11 02 40](https://github.com/safe-global/safe-homepage/assets/32431609/e6eb414f-d89e-4123-83f9-af72354223cd)

## Figma
https://www.figma.com/file/zNUgOvD1WcFankfXfBiAfs/Press-room?type=design&node-id=9929-4249&mode=design&t=x13Zf5TNtfe0ytJN-0