### PR TITLE
fix: default to a total assets static value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "safe-homepage",
   "homepage": "https://github.com/safe-global/safe-homepage",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "scripts": {
     "build": "next build && next export",
     "lint": "tsc && next lint",

--- a/src/content/home.json
+++ b/src/content/home.json
@@ -28,21 +28,21 @@
     "text": "Previously called Gnosis Safe, <i>Safe</i> spun out with a mission to build a better standard for ownership with smart accounts",
     "items": [
       {
-        "title": "17M",
+        "title": "39M",
         "text": "Total transactions",
         "link": {
           "href": "https://dune.com/queries/2093960/3449499"
         }
       },
       {
-        "title": "$52B",
+        "title": "$124B",
         "text": "Total assets stored",
         "link": {
           "href": "https://dune.com/queries/2893829/4821383"
         }
       },
       {
-        "title": "4.4M",
+        "title": "7.6M",
         "text": "Safe accounts deployed",
         "link": {
           "href": "https://dune.com/queries/2459401/4044167"

--- a/src/hooks/useSafeStats.ts
+++ b/src/hooks/useSafeStats.ts
@@ -5,7 +5,7 @@ import { DUNE_API_KEY } from '@/config/constants'
 import { duneQueryUrlBuilder } from '@/lib/duneQueryUrlBuilder'
 
 const QUERY_ID_TOTAL_TRANSACTIONS = 2093960
-const QUERY_ID_TOTAL_ASSETS = 2893829
+// const QUERY_ID_TOTAL_ASSETS = 2893829
 const QUERY_ID_TOTAL_SAFES_DEPLOYED = 2459401
 
 export const fetchTotalTransactions = async (): Promise<number | null> => {
@@ -16,10 +16,12 @@ export const fetchTotalTransactions = async (): Promise<number | null> => {
 }
 
 export const fetchTotalAssets = async (): Promise<number | null> => {
-  return fetch(duneQueryUrlBuilder(QUERY_ID_TOTAL_ASSETS, DUNE_API_KEY))
-    .then((res) => res.json())
-    .then((data) => data.result.rows[0].usd_value)
-    .catch(() => null)
+  return null
+  // Dune query has a but that needs to be fixed so defaulting to a static value
+  // return fetch(duneQueryUrlBuilder(QUERY_ID_TOTAL_ASSETS, DUNE_API_KEY))
+  //   .then((res) => res.json())
+  //   .then((data) => data.result.rows[0].usd_value)
+  //   .catch(() => null)
 }
 
 export const fetchTotalSafesDeployed = async (): Promise<number | null> => {


### PR DESCRIPTION
Because Dune's total assets stored query is returning a wrong value we should use the fallback value instead of fetching.
