### PR TITLE
fix: remove duplicated "Press Releases" section

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "safe-homepage",
   "homepage": "https://github.com/safe-global/safe-homepage",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "scripts": {
     "build": "next build && next export",
     "lint": "tsc && next lint",

--- a/src/components/Pressroom/index.tsx
+++ b/src/components/Pressroom/index.tsx
@@ -60,7 +60,6 @@ const PressRoom = ({ pressRoom, allPosts, totalAssets }: PressRoomProps) => {
         <News news={newsList} />
         <Podcasts podcasts={podcastsList} />
         <FeaturedVideos videos={videosList} />
-        <PressReleases allPosts={pressPosts} />
         <MediaKit />
       </Container>
     </>


### PR DESCRIPTION
Removes a duplicated section in the Pressroom landing page.