### PR TITLE
fix: nested h1 span selector was broken in safari

### DIFF
--- a/src/components/Home/HeroVideo/styles.module.css
+++ b/src/components/Home/HeroVideo/styles.module.css
@@ -31,11 +31,11 @@
   text-align: center;
   text-wrap: nowrap;
   margin-top: 30px;
+}
 
-  & .hl {
-    color: var(--mui-palette-primary-main);
-    display: block;
-  }
+.hl {
+  color: var(--mui-palette-primary-main);
+  display: block;
 }
 
 .title {


### PR DESCRIPTION
HeroVideo title styling was broken in desktop Safari due to nested selectors not rendering properly - fixed by removing nesting