### PR TITLE
feat: Ticker component text now displays as continuous gradient

### DIFF
--- a/src/components/Home/SafeAtScale/Ticker.module.css
+++ b/src/components/Home/SafeAtScale/Ticker.module.css
@@ -7,7 +7,7 @@
 
 .digit,
 .char {
-  color: color-mix(in oklab, var(--mui-palette-info-main) calc(var(--i) * 100%), var(--mui-palette-primary-main));
+  color: transparent;
 
   opacity: 0;
   transition: opacity 300ms ease calc(var(--i) * 600ms);
@@ -46,12 +46,28 @@
   transition: transform var(--roll-duration) ease var(--roll-delay);
 }
 
+.scale > span,
+.char {
+  /*
+    construct gradient piecewise between chars 
+    since gradient clipping does not work for 
+    relative-positioned elements
+  */
+  --left-idx: calc((var(--len) - 1) * var(--i));
+  --right-idx: calc(var(--len) - var(--left-idx));
+  background: linear-gradient(
+    90deg,
+    var(--mui-palette-primary-main) calc(var(--left-idx) * -140%),
+    var(--mui-palette-info-main)    calc(var(--right-idx) * 140%)
+  );
+  background-clip: text;
+}
+
 .scale span {
   opacity: calc(1 - var(--dist));
 }
 
 .scale span:last-child {
-  /* . */
   position: absolute;
   bottom: -10%;
   left: 0;
@@ -89,7 +105,4 @@
 }
 [data-value='9'] .scale {
   transform: translateY(-90%);
-}
-[data-value='-'] .scale {
-  transform: translateY(-100%);
 }

--- a/src/components/Home/SafeAtScale/TickerElement.tsx
+++ b/src/components/Home/SafeAtScale/TickerElement.tsx
@@ -65,7 +65,10 @@ const TickerElement = ({
   }, [run, toValue, delayTimeMs])
 
   return (
-    <span className={`${className} ${css.wrapper} ${run ? css.run : ''}`}>
+    <span
+      className={`${className} ${css.wrapper} ${run ? css.run : ''}`}
+      style={{ '--len': chars.length } as CSSProperties}
+    >
       {chars.map((c, i) => {
         if (isNumber(c)) {
           return (

--- a/src/hooks/useScrollReveal.ts
+++ b/src/hooks/useScrollReveal.ts
@@ -23,6 +23,7 @@ const useScrollReveal = (elementRef: RefObject<HTMLElement>, percentVisible: num
     }
 
     window.addEventListener('scroll', handleScroll)
+    handleScroll()
 
     return () => {
       window.removeEventListener('scroll', handleScroll)


### PR DESCRIPTION
working around a CSS limitation in which `background-clip: text` does not work for relative-positioned children, gradients are now constructed piecewise per-character