### PR TITLE
styles: homepage styles fix

### DIFF
--- a/src/components/Home/SafeAtScale/styles.module.css
+++ b/src/components/Home/SafeAtScale/styles.module.css
@@ -41,14 +41,12 @@
 }
 
 .caption {
-  text-align: left;
   z-index: 1;
 }
 
 .title {
-  text-align: left;
+  z-index: 1;
   margin-top: 24px;
-  text-wrap: balance;
 }
 
 .title br {
@@ -167,10 +165,6 @@
     font-size: 80px;
     line-height: 100px;
   }
-
-  .caption {
-    text-align: center;
-  }
 }
 
 @media (min-width: 900px) {
@@ -181,11 +175,9 @@
   .caption {
     text-wrap: nowrap;
     white-space: nowrap;
-    text-align: center;
   }
 
   .title {
-    text-align: center;
     margin: 24px auto;
   }
 

--- a/src/components/Token/ButtonsWrapper/index.tsx
+++ b/src/components/Token/ButtonsWrapper/index.tsx
@@ -1,6 +1,6 @@
 import LinkButton from '@/components/common/LinkButton'
 import { Button } from '@mui/material'
-import SafeLink from '@/components/common/SafeLink'
+import NextLink from 'next/link'
 import { type ButtonEntry } from '@/config/types'
 import css from './styles.module.css'
 
@@ -16,7 +16,7 @@ const ButtonsWrapper = ({ buttons }: ButtonsWrapperProps) => {
         const isButton = variant === 'button'
 
         return (
-          <SafeLink key={index} href={href} isDisabled={!!isDisabled}>
+          <NextLink key={index} href={href} target="_blank" className={`${isDisabled ? css.disabled : ''}`}>
             {isButton ? (
               <Button variant="contained" size="large" disabled={!!isDisabled}>
                 {text}
@@ -24,7 +24,7 @@ const ButtonsWrapper = ({ buttons }: ButtonsWrapperProps) => {
             ) : (
               <LinkButton>{text}</LinkButton>
             )}
-          </SafeLink>
+          </NextLink>
         )
       })}
     </div>

--- a/src/components/Token/CenteredTitleCards/styles.module.css
+++ b/src/components/Token/CenteredTitleCards/styles.module.css
@@ -5,7 +5,7 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
-  border-radius: 8px;
+  border-radius: 16px;
   align-items: flex-start;
 }
 

--- a/src/components/Token/LinkCard/styles.module.css
+++ b/src/components/Token/LinkCard/styles.module.css
@@ -6,7 +6,7 @@
   display: flex;
   flex-direction: column;
   gap: 32px;
-  border-radius: 8px;
+  border-radius: 16px;
   transition-duration: var(--transition-duration);
   height: 300px;
   background-color: var(--mui-palette-background-default);

--- a/src/components/common/RichText/index.tsx
+++ b/src/components/common/RichText/index.tsx
@@ -21,7 +21,14 @@ import Twitter from '@/components/Blog/Twitter'
 const generateTextContent = (node: Heading1 | Heading2 | Heading3 | Heading5) => {
   return node.content.filter(isText).map((node, index) => {
     const isBold = node.marks.some((mark) => mark.type === 'bold')
-    return isBold ? <b key={index}>{node.value}</b> : <span key={index}>{node.value}</span>
+    const isItalic = node.marks.some((mark) => mark.type === 'italic')
+    return isBold ? (
+      <b key={index}>{node.value}</b>
+    ) : isItalic ? (
+      <i key={index}>{node.value}</i>
+    ) : (
+      <span key={index}>{node.value}</span>
+    )
   })
 }
 

--- a/src/components/common/styles.module.css
+++ b/src/components/common/styles.module.css
@@ -13,6 +13,11 @@
   display: none;
 }
 
+.centeredContent {
+  display: flex;
+  flex-direction: column;
+}
+
 @media (min-width: 600px) {
   .hideMobile {
     display: block;
@@ -34,11 +39,9 @@
     margin-top: 150px;
     margin-bottom: 150px;
   }
-}
 
-.centeredContent {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
+  .centeredContent {
+    justify-content: center;
+    align-items: center;
+  }
 }


### PR DESCRIPTION
- give `z-index` to title behind gradient
- accept RichText italic marks
- use 16px `border-radius` in the Token landing page
- use next/link in the SafePass landing page