### PR TITLE
feat: do not display "Press Release" posts in the Blog landing page

### DIFF
--- a/src/components/Blog/BlogHome/index.tsx
+++ b/src/components/Blog/BlogHome/index.tsx
@@ -4,6 +4,7 @@ import Card from '@/components/Blog/Card'
 import FeaturedPost from '@/components/Blog/FeaturedPost'
 import { type BlogPostEntry } from '@/components/Blog/Post'
 import SearchFilterResults from '@/components/Blog/SearchFilterResults'
+import { containsTag, PRESS_RELEASE_TAG } from '@/lib/containsTag'
 
 const categories = ['Announcements', 'Ecosystem', 'Community', 'Insights', 'Build']
 
@@ -18,6 +19,8 @@ export type BlogHomeProps = {
 
 const BlogHome = (props: BlogHomeProps) => {
   const { featuredPost, mostPopular, allPosts, metaTags } = props
+
+  const nonPressReleases = allPosts.filter((post) => !containsTag(post.fields.tags, PRESS_RELEASE_TAG))
 
   return (
     <BlogLayout metaTags={metaTags}>
@@ -48,7 +51,7 @@ const BlogHome = (props: BlogHomeProps) => {
         </Grid>
 
         {/* All posts */}
-        <SearchFilterResults allPosts={allPosts} categories={categories} />
+        <SearchFilterResults allPosts={nonPressReleases} categories={categories} />
       </Container>
     </BlogLayout>
   )


### PR DESCRIPTION
## What it solves
Do not include Press Release posts in [https://safe.global/blog ](https://safe.global/blog ) to avoid very similar content duplicated.

Example
![Screenshot 2024-05-13 at 15 39 21](https://github.com/safe-global/safe-homepage/assets/32431609/d376a359-0d95-4439-89a8-6000be6b9bbc)
