### PR TITLE
fix: remove duplicated page route

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -20,7 +20,7 @@ jobs:
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ACCESS_TOKEN }}
         with:
           path-to-signatures: 'signatures/version1/cla.json'
-          path-to-document: 'https://safe.global/cla/' # e.g. a CLA or a DCO document
+          path-to-document: 'https://safe.global/cla' # e.g. a CLA or a DCO document
           # branch should not be protected
           branch: 'main'
           # user names of users allowed to contribute without CLA

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -14,9 +14,7 @@ export const AppRoutes = {
   disclaimer: '/disclaimer',
   core: '/core',
   cookie: '/cookie',
-  cla: {
-    index: '/cla',
-  },
+  cla: '/cla',
   careers: '/careers',
   blog: {
     index: '/blog',

--- a/src/pages/cla/index.tsx
+++ b/src/pages/cla/index.tsx
@@ -1,2 +1,0 @@
-import CLAPage from '../cla'
-export default CLAPage


### PR DESCRIPTION
## What it solves

Resolves #183

Redirection on the server side was dismissed on https://5afe.slack.com/archives/C049H57FS1E/p1686737485728239?thread_ts=1686069103.973699&cid=C049H57FS1E and preferred to use the correct exact path, ie., without the trailing forward slash.
