### PR TITLE
fix: uses category as map key

### DIFF
--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -47,7 +47,7 @@ const Header = () => {
             const onLeave = () => setSubMenuOpen(null)
 
             return (
-              <li key={href} onMouseEnter={onEnter} onFocus={onEnter} onMouseLeave={onLeave} onBlur={onLeave}>
+              <li key={category} onMouseEnter={onEnter} onFocus={onEnter} onMouseLeave={onLeave} onBlur={onLeave}>
                 {href ? (
                   <NextLink href={href} onClick={closeMobileNavigation}>
                     <span className={css.navLink} dangerouslySetInnerHTML={{ __html: category }} />


### PR DESCRIPTION
Uses category as map key.
`href` is undefined for the buttons with submenus.