### PR TITLE
feat: Scheduled deployment CI job

### DIFF
--- a/.github/workflows/scheduled-deployment.yml
+++ b/.github/workflows/scheduled-deployment.yml
@@ -1,0 +1,52 @@
+name: Scheduled deployment
+
+on:
+  schedule:
+    - cron: '38 9,13,15 * * *' # Every day at 9:38, 13:38, 15:38 UTC
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions: write-all
+
+    name: Deploy last release
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch all tags
+        run: git fetch --tags
+
+      - name: Set an output variable with the latest tag
+        id: latest_tag
+        shell: bash
+        run: echo "latest_tag=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_OUTPUT
+
+      - name: Checkout latest tag
+        run: git checkout ${{ steps.latest_tag.outputs.latest_tag }}
+
+      - name: Install dependencies
+        uses: ./.github/workflows/yarn
+
+      - name: Build
+        uses: ./.github/workflows/build
+        with:
+          secrets: ${{ toJSON(secrets) }}
+          is-production: ${{ true }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      # Script to upload release files
+      - name: 'Upload release build files for production'
+        env:
+          #
+          BUCKET: s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/releases/${{ steps.latest_tag.outputs.latest_tag }}
+        run: bash ./scripts/github/s3_upload.sh


### PR DESCRIPTION
## What it solves
- Adds a new workflow to run a scheduled build and deployment on the latest tag.
- Given the limitation of Next.js static exports, a new build has to run to include new files in the production server.

