### PR TITLE
fix(blog): sharing icons should inherit the color

### DIFF
--- a/src/components/Blog/ContentsTable/index.tsx
+++ b/src/components/Blog/ContentsTable/index.tsx
@@ -5,6 +5,7 @@ import { useMemo } from 'react'
 import { scrollToElement } from '@/lib/scrollSmooth'
 import { Typography } from '@mui/material'
 import Link from 'next/link'
+import css from '../styles.module.css'
 
 const ContentsTable = ({ content }: { content: ContentfulDocument }) => {
   const handleContentTableClick = (e: React.MouseEvent<HTMLAnchorElement>, target: string) => {
@@ -25,7 +26,7 @@ const ContentsTable = ({ content }: { content: ContentfulDocument }) => {
   )
 
   return (
-    <ul>
+    <ul className={css.contentsTable}>
       {headings.map((heading) => {
         const headingKey = kebabCase(heading.id)
 

--- a/src/components/Blog/Post/index.tsx
+++ b/src/components/Blog/Post/index.tsx
@@ -83,7 +83,9 @@ const BlogPost = ({ blogPost }: { blogPost: BlogPostEntry }) => {
 
             <Sidebar content={content} title={title} authors={authorsList} isPressRelease={isPressRelease} showInXs />
 
-            <RichText {...content} />
+            <div className={css.postBody}>
+              <RichText {...content} />
+            </div>
           </Grid>
         </Grid>
 
@@ -111,6 +113,7 @@ const Sidebar = ({
   <Grid item xs={12} md={4} className={showInXs ? css.showInXs : css.showInMd}>
     <aside className={css.sidebar}>
       <ContentsTable content={content} />
+
       <Socials title={title} authors={authors} />
 
       {isPressRelease ? (

--- a/src/components/Blog/styles.module.css
+++ b/src/components/Blog/styles.module.css
@@ -77,11 +77,13 @@
   font-weight: bold;
 }
 
-.content a {
+.postBody a,
+.contentsTable a {
   color: var(--mui-palette-primary-main);
 }
 
-.content a:hover {
+.postBody a:hover,
+.contentsTable a:hover {
   text-decoration: underline;
 }
 


### PR DESCRIPTION
## What it solves
The social icon in the blog post was incorrectly displaying as green instead of white.

<img width="168" alt="Screenshot 2024-08-01 at 15 03 54" src="https://github.com/user-attachments/assets/ba9e36b2-e74b-4fe8-b828-ec98d4e47f77">

## How to test it
1. Go to one of the blog articles, e.g., [Safe Wallet Introduces Native Swaps](https://style_blog_share_buttons--homepage.review.5afe.dev/blog/safe-wallet-introduces-native-swaps).
2. Verify that the social icon is now white, matching the [designs](https://www.figma.com/design/qtXXlwdslAze6yNbLLzIRa/Website-redesign-2.0?node-id=14969-4870&t=6qwLvCPkIxmVExdW-0).
