### PR TITLE
feat: add CSP header to all the pages

### DIFF
--- a/src/components/common/MetaTags/index.tsx
+++ b/src/components/common/MetaTags/index.tsx
@@ -1,4 +1,5 @@
 import { IS_PRODUCTION } from '@/config/constants'
+import { ContentSecurityPolicy } from '@/config/securityHeaders'
 import Head from 'next/head'
 
 const defaultMetaTags = {
@@ -30,6 +31,9 @@ const MetaTags = (props: Partial<typeof defaultMetaTags>) => {
       <meta name="twitter:image" content={seo.image} />
 
       {!IS_PRODUCTION && <meta name="robots" content="noindex" />}
+
+      {/* CSP */}
+      <meta httpEquiv="Content-Security-Policy" content={ContentSecurityPolicy} />
 
       {/* Mobile tags */}
       <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/src/config/securityHeaders.ts
+++ b/src/config/securityHeaders.ts
@@ -9,7 +9,7 @@ import { IS_PRODUCTION } from '@/config/constants'
  */
 export const ContentSecurityPolicy = `
  default-src 'self';
- connect-src 'self' https://api.ashbyhq.com/posting-api/job-board/safe.global/ https://ecosystem-database.staging.5afe.dev/data.json https://hub.snapshot.org/graphql https://cdn.contentful.com/spaces/1i5gc724wjeu/ https://metrics.hotjar.io/;
+ connect-src 'self' https://api.ashbyhq.com/posting-api/job-board/safe.global/ https://ecosystem-database.staging.5afe.dev/data.json https://hub.snapshot.org/graphql https://cdn.contentful.com/spaces/1i5gc724wjeu/ https://metrics.hotjar.io/ https://content.hotjar.io/ wss://ws.hotjar.com;
  script-src 'self' ${
    IS_PRODUCTION ? '' : "'unsafe-eval'"
  } 'unsafe-inline' https://script.hotjar.com https://static.hotjar.com https://www.googletagmanager.com;

--- a/src/config/securityHeaders.ts
+++ b/src/config/securityHeaders.ts
@@ -5,7 +5,7 @@ export const ContentSecurityPolicy = `
  connect-src 'self' https://api.ashbyhq.com/posting-api/job-board/safe.global/ https://ecosystem-database.staging.5afe.dev/data.json https://hub.snapshot.org/graphql https://cdn.contentful.com/spaces/1i5gc724wjeu/ https://metrics.hotjar.io/;
  script-src 'self' ${
    IS_PRODUCTION ? '' : "'unsafe-eval'"
- } 'unsafe-inline' https://static.hotjar.com/c/hotjar-3603830.js https://www.googletagmanager.com;
+ } 'unsafe-inline' https://script.hotjar.com https://static.hotjar.com https://www.googletagmanager.com;
  style-src 'self' 'unsafe-inline';
  font-src 'self';
  object-src 'none';

--- a/src/config/securityHeaders.ts
+++ b/src/config/securityHeaders.ts
@@ -2,14 +2,16 @@ import { IS_PRODUCTION } from '@/config/constants'
 
 export const ContentSecurityPolicy = `
  default-src 'self';
- connect-src 'self' https://api.ashbyhq.com/posting-api/job-board/safe.global/;
+ connect-src 'self' https://api.ashbyhq.com/posting-api/job-board/safe.global/ https://ecosystem-database.staging.5afe.dev/data.json https://hub.snapshot.org/graphql https://cdn.contentful.com/spaces/1i5gc724wjeu/ https://metrics.hotjar.io/;
  script-src 'self' ${
    IS_PRODUCTION ? '' : "'unsafe-eval'"
- } 'unsafe-inline' https://static.hotjar.com/c/hotjar-3603830.js;
+ } 'unsafe-inline' https://static.hotjar.com/c/hotjar-3603830.js https://www.googletagmanager.com;
  style-src 'self' 'unsafe-inline';
- font-src 'self' data:;
+ font-src 'self';
  object-src 'none';
  base-uri 'none';
+ img-src 'self' http://images.ctfassets.net/ https://ecosystem-database.staging.5afe.dev/logos/ https://safe-claiming-app-data.safe.global/guardians/images/ data:;
+ frame-src https://safe.mirror.xyz/ https://www.youtube-nocookie.com/ https://cdn.jwplayer.com/;
 `
   .replace(/\s{2,}/g, ' ')
   .trim()

--- a/src/config/securityHeaders.ts
+++ b/src/config/securityHeaders.ts
@@ -1,0 +1,15 @@
+import { IS_PRODUCTION } from '@/config/constants'
+
+export const ContentSecurityPolicy = `
+ default-src 'self';
+ connect-src 'self' https://api.ashbyhq.com/posting-api/job-board/safe.global/;
+ script-src 'self' ${
+   IS_PRODUCTION ? '' : "'unsafe-eval'"
+ } 'unsafe-inline' https://static.hotjar.com/c/hotjar-3603830.js;
+ style-src 'self' 'unsafe-inline';
+ font-src 'self' data:;
+ object-src 'none';
+ base-uri 'none';
+`
+  .replace(/\s{2,}/g, ' ')
+  .trim()

--- a/src/config/securityHeaders.ts
+++ b/src/config/securityHeaders.ts
@@ -1,5 +1,12 @@
 import { IS_PRODUCTION } from '@/config/constants'
 
+/**
+ * Notes:
+ * connect-src: Allows calls to Ashby's job board, Ecosystem DB API, Snapshot, Contentful and Hotjar.
+ * script-src: Allows scripts from Hotjar, and Google Tag Manager. In development, 'unsafe-eval' is allowed for inline scripts to facilitate debugging.
+ * img-src: Allows images from Contentful, Ecosystem DB for the project logos, Safe Claiming App for guardians images, and data URIs.
+ * frame-src: Allows iframes from Mirror, Youtube and JWPlayer.
+ */
 export const ContentSecurityPolicy = `
  default-src 'self';
  connect-src 'self' https://api.ashbyhq.com/posting-api/job-board/safe.global/ https://ecosystem-database.staging.5afe.dev/data.json https://hub.snapshot.org/graphql https://cdn.contentful.com/spaces/1i5gc724wjeu/ https://metrics.hotjar.io/;


### PR DESCRIPTION
## What it solves
Adds an explicit Content Security Policy to the website pages

## How this PR fixes it
Sets the Content Security Policy through a `<meta>` tag

I tried to keep the allowed `src` lists as restrictive as possible without braking anything or lose of functionality