### PR TITLE
fix: WorldGDP video plays inline

### DIFF
--- a/src/components/DataRoom/WorldGDP/SlidingVideo.tsx
+++ b/src/components/DataRoom/WorldGDP/SlidingVideo.tsx
@@ -3,7 +3,7 @@ import css from './styles.module.css'
 
 const SlidingVideo = () => (
   <MotionTypography animateYFrom={-30} customDelay={0.2}>
-    <video className={css.video} src="/videos/DataRoom/SafeGlobe.mp4" autoPlay muted loop />
+    <video className={css.video} src="/videos/DataRoom/SafeGlobe.mp4" autoPlay playsInline muted loop />
   </MotionTypography>
 )
 


### PR DESCRIPTION
## What it solves
- WorldGDP video plays inline
- Dropping tokens do not cut previous section