### PR TITLE
feat: use TVP data instead of TVL for comparison with World GDP

### DIFF
--- a/src/components/DataRoom/VolumeTransferred/SlidingText.tsx
+++ b/src/components/DataRoom/VolumeTransferred/SlidingText.tsx
@@ -9,7 +9,7 @@ import css from './styles.module.css'
 const VOLUME_TRANSFERRED_FALLBACK = 611_127_712_666
 
 const SlidingText = ({ containerRef }: { containerRef: RefObject<HTMLDivElement> }) => {
-  const { totalVolumeTransfered } = useSafeDataRoomStats()
+  const { totalVolumeTransferred } = useSafeDataRoomStats()
   const { scrollYProgress } = useScrollProgress(containerRef)
 
   const transformLTR = useTransform(scrollYProgress, [0.25, 0.75], ['-100%', '120%'])
@@ -17,7 +17,7 @@ const SlidingText = ({ containerRef }: { containerRef: RefObject<HTMLDivElement>
   const opacityLTR = useTransform(scrollYProgress, [0.25, 0.3, 0.7, 0.75], [0, 1, 1, 0])
   const opacityRTL = useTransform(scrollYProgress, [0.25, 0.3, 0.7, 0.75], [0, 1, 1, 0])
 
-  const volumeTransferred = totalVolumeTransfered || VOLUME_TRANSFERRED_FALLBACK
+  const volumeTransferred = totalVolumeTransferred || VOLUME_TRANSFERRED_FALLBACK
   const displayValue = formatCurrency(volumeTransferred, 0)
 
   return (

--- a/src/components/DataRoom/WorldGDP/SlidingText.tsx
+++ b/src/components/DataRoom/WorldGDP/SlidingText.tsx
@@ -5,16 +5,16 @@ import { formatCurrency } from '@/lib/formatCurrency'
 import { type BaseBlock } from '@/components/Home/types'
 import css from './styles.module.css'
 
-const VALUE_LOCKED_FALLBACK = 68_583_703_689
-const PERCENTAGE_FALLBACK = 0.000679
+const VOLUME_TRANSFERRED_FALLBACK = 759_488_208_315 // 759.48 billion
+const PERCENTAGE_FALLBACK = 0.001576
 
 const SlidingText = ({ title }: { title: BaseBlock['title'] }) => {
-  const { tvlToGDPPercentage, totalValueLocked } = useSafeDataRoomStats()
+  const { tvpToGDPPercentage, totalVolumeTransferred } = useSafeDataRoomStats()
 
-  const valueLocked = totalValueLocked || VALUE_LOCKED_FALLBACK
-  const percentageValue = tvlToGDPPercentage || PERCENTAGE_FALLBACK
+  const valueProcessed = totalVolumeTransferred || VOLUME_TRANSFERRED_FALLBACK
+  const percentageValue = tvpToGDPPercentage || PERCENTAGE_FALLBACK
 
-  const displayTVLValue = formatCurrency(valueLocked, 0)
+  const displayTVPValue = formatCurrency(valueProcessed, 0)
   const percentageToDisplay = '~' + (percentageValue * 100).toFixed(2) + '%'
 
   return (
@@ -27,7 +27,7 @@ const SlidingText = ({ title }: { title: BaseBlock['title'] }) => {
 
       <MotionTypography animateYFrom={-30} customDelay={0.7}>
         <Typography variant="h1" color="primary.main" align="center">
-          {displayTVLValue}
+          {displayTVPValue}
         </Typography>
       </MotionTypography>
     </div>

--- a/src/content/dataroom.json
+++ b/src/content/dataroom.json
@@ -12,11 +12,11 @@
   },
   {
     "component": "DataRoom/WorldGDP",
-    "title": "<b><em>Safe</em> TVL</b> is",
-    "text": "Total value secured in <em>Safe</em> Smart Accounts can already be seen in comparison to world GDP.",
+    "title": "<b><em>Safe</em> TVP</b> is",
+    "text": "Total Volume Processed in <em>Safe</em> Smart Accounts can already be seen in comparison to World GDP.",
     "link": {
       "title": "Dune dashboard",
-      "href": "https://dune.com/queries/3710102/6242478"
+      "href": "https://dune.com/safe/all"
     }
   },
   {

--- a/src/contexts/SafeDataRoomContext.ts
+++ b/src/contexts/SafeDataRoomContext.ts
@@ -1,10 +1,10 @@
 import { createContext } from 'react'
 
 type SafeDataRoomStats = {
-  tvlToGDPPercentage: number | null
+  tvpToGDPPercentage: number | null
   usdcPercentageStored: number | null
   cryptoPunksStoredPercentage: number | null
-  totalVolumeTransfered: number | null
+  totalVolumeTransferred: number | null
   onChainTransactionsPercentage: number | null
   tvlSafe: number | null
   tvlRobinhoodCEX: number | null
@@ -15,10 +15,10 @@ type SafeDataRoomStats = {
 }
 
 const SafeDataRoomContext = createContext<SafeDataRoomStats>({
-  tvlToGDPPercentage: null,
+  tvpToGDPPercentage: null,
   usdcPercentageStored: null,
   cryptoPunksStoredPercentage: null,
-  totalVolumeTransfered: null,
+  totalVolumeTransferred: null,
   onChainTransactionsPercentage: null,
   tvlSafe: null,
   tvlRobinhoodCEX: null,

--- a/src/hooks/useSafeDataRoomStats.ts
+++ b/src/hooks/useSafeDataRoomStats.ts
@@ -19,7 +19,7 @@ type DuneDataRoomStats = {
   total_transfer_volume: number
   total_usdc_share: number
   transaction_share: number
-  tvl_perc_world_gdp: number
+  tvp_perc_world_gdp: number
   usdc_in_safes: number
   last_updated: number
   annual_swap_fees: number

--- a/src/pages/dataroom.tsx
+++ b/src/pages/dataroom.tsx
@@ -12,7 +12,7 @@ export async function getStaticProps() {
   if (!dataRoomStats) return null
 
   const {
-    tvl_perc_world_gdp,
+    tvp_perc_world_gdp,
     total_usdc_share,
     crypto_punks_perc,
     total_transfer_volume,
@@ -28,11 +28,11 @@ export async function getStaticProps() {
   return {
     props: {
       safeDataRoomStats: {
-        tvlToGDPPercentage: tvl_perc_world_gdp,
+        tvpToGDPPercentage: tvp_perc_world_gdp,
         usdcPercentageStored: total_usdc_share,
         // This is a temp workaround. The received value should be a number.
         cryptoPunksStoredPercentage: Number(crypto_punks_perc),
-        totalVolumeTransfered: total_transfer_volume,
+        totalVolumeTransferred: total_transfer_volume,
         onChainTransactionsPercentage: transaction_share,
         tvlSafe: Number(safe_tvl),
         tvlRobinhoodCEX: Number(cex_tvl_robinhood),


### PR DESCRIPTION
## What it solves
- Adapt the World GDP section of the Data room to display the TVP as World GDP percentage.
- Fixes typo `totalVolumeTransfered` -> `totalVolumeTransferred`


<img width="1238" alt="Screenshot 2024-09-24 at 15 58 27" src="https://github.com/user-attachments/assets/4c9af89c-b1ba-4811-9a7e-ea2a76795781">

