### PR TITLE
fix(blog): truncate featured article title and excerpt

### DIFF
--- a/src/components/Blog/FeaturedPost/index.tsx
+++ b/src/components/Blog/FeaturedPost/index.tsx
@@ -23,7 +23,7 @@ const FeaturedPost = ({ post }: { post: BlogPostEntry }) => {
         </Typography>
       ) : null}
       <Grid container columnSpacing="60px" rowGap={3}>
-        <Grid item md={7}>
+        <Grid item lg={7}>
           {isAsset(coverImage) && coverImage.fields.file?.url ? (
             <Link href={`/blog/${slug}`}>
               <Image
@@ -37,7 +37,7 @@ const FeaturedPost = ({ post }: { post: BlogPostEntry }) => {
           ) : undefined}
         </Grid>
 
-        <Grid item md={5} className={css.body}>
+        <Grid item lg={5} className={css.body}>
           <div className={css.meta}>
             <div className={css.metaStart}>
               <CategoryIcon />

--- a/src/components/Blog/FeaturedPost/index.tsx
+++ b/src/components/Blog/FeaturedPost/index.tsx
@@ -58,7 +58,7 @@ const FeaturedPost = ({ post }: { post: BlogPostEntry }) => {
 
           <Typography className={css.excerpt}>{excerpt}</Typography>
 
-          <Box mt={2}>
+          <Box mt="auto">
             <Tags tags={tags} />
           </Box>
         </Grid>

--- a/src/components/Blog/FeaturedPost/styles.module.css
+++ b/src/components/Blog/FeaturedPost/styles.module.css
@@ -39,6 +39,11 @@
 .title,
 .excerpt {
   margin-top: 16px;
+  overflow: hidden;
+  display: -webkit-box;
+  line-clamp: 3;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
 }
 
 .title a {

--- a/src/components/Blog/FeaturedPost/styles.module.css
+++ b/src/components/Blog/FeaturedPost/styles.module.css
@@ -19,7 +19,7 @@
 .body {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 16px;
 }
 
 .meta {
@@ -38,7 +38,6 @@
 
 .title,
 .excerpt {
-  margin-top: 16px;
   overflow: hidden;
   display: -webkit-box;
   line-clamp: 3;
@@ -60,8 +59,11 @@
   .image {
     height: 100%;
   }
+}
 
-  .title {
-    margin-top: 24px;
+@media (min-width: 1630px) {
+  .excerpt {
+    line-clamp: 5;
+    -webkit-line-clamp: 5;
   }
 }

--- a/src/components/Governance/Delegates/styles.module.css
+++ b/src/components/Governance/Delegates/styles.module.css
@@ -25,6 +25,7 @@
 .name {
   overflow: hidden;
   display: -webkit-box;
+  line-clamp: 1;
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
 }
@@ -32,6 +33,7 @@
 .description {
   overflow: hidden;
   display: -webkit-box;
+  line-clamp: 2;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
 }


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/safe-homepage/issues/452

## How this PR fixes it
- Truncates the _Featured_ post title and excerpt

## Other changes
- CMS: limited the number of chars in a blog post title to 75

## How to test it
Navigate to `/press` or `/blog` and verify the _Featured article_ layout is responsive without breaking the image content

<img width="1211" alt="Screenshot 2024-09-25 at 14 57 50" src="https://github.com/user-attachments/assets/04b6c58a-c9cb-4810-bd46-0f1320258155">
