### PR TITLE
Fix links

### DIFF
--- a/src/components/DataRoom/USDCStorage/SlidingText.tsx
+++ b/src/components/DataRoom/USDCStorage/SlidingText.tsx
@@ -53,7 +53,11 @@ const SlidingText = ({ containerRef, title, text, link }: SlidingTextProps) => {
           {text}
         </Typography>
 
-        {link && <LinksWrapper link={link} />}
+        {link && (
+          <div className={css.overlay}>
+            <LinksWrapper link={link} />
+          </div>
+        )}
       </MotionTypography>
     </motion.div>
   )

--- a/src/components/DataRoom/USDCStorage/styles.module.css
+++ b/src/components/DataRoom/USDCStorage/styles.module.css
@@ -22,6 +22,14 @@
   margin-bottom: 70px;
 }
 
+.overlay {
+  background: rgba(255, 255, 255, 0.005);
+  backdrop-filter: blur(16px);
+  width: min-content;
+  padding-inline: 16px;
+  border-radius: 8px;
+}
+
 .content {
   width: 50%;
   display: flex;
@@ -34,6 +42,7 @@
 .canvas {
   width: 50%;
   height: 100%;
+  z-index: -1;
 }
 
 @media (max-width: 900px) {

--- a/src/components/DataRoom/WorldGDP/SlidingText.tsx
+++ b/src/components/DataRoom/WorldGDP/SlidingText.tsx
@@ -26,7 +26,7 @@ const SlidingText = ({ title }: { title: BaseBlock['title'] }) => {
       </MotionTypography>
 
       <MotionTypography animateYFrom={-30} customDelay={0.7}>
-        <Typography variant="h1" color="primary.main" align="center">
+        <Typography variant="h2" color="primary.main" align="center">
           {displayTVPValue}
         </Typography>
       </MotionTypography>


### PR DESCRIPTION
## What it solves
Links are un-clickable after the UDSC animation in mobile viewports

## How this PR fixes it
- Sets the MatterJS animation in the background of the section
- Gives a glossy overlay to the links wrapper in that same section