### PR TITLE
fix: return null in the catch block

### DIFF
--- a/src/lib/fetchTotalSafesDeployed.ts
+++ b/src/lib/fetchTotalSafesDeployed.ts
@@ -13,5 +13,8 @@ export const fetchTotalSafesDeployed = async (): Promise<number | null> => {
       return res.json()
     })
     .then((data) => data.result.rows[0].num_safes)
-    .catch((err) => console.error(`Error fetching total safes deployed: ${err.message}`))
+    .catch((err) => {
+      console.error(`Error fetching total safes deployed: ${err.message}`)
+      return null
+    })
 }

--- a/src/lib/fetchTotalTransactions.ts
+++ b/src/lib/fetchTotalTransactions.ts
@@ -14,7 +14,7 @@ export const fetchTotalTransactions = async (): Promise<number | null> => {
     })
     .then((data) => data.result.rows[0].num_txs)
     .catch((err) => {
-      console.log(`Error fetching total number of transactions: ${err.message}`)
+      console.error(`Error fetching total number of transactions: ${err.message}`)
       return null
     })
 }

--- a/src/lib/fetchTotalTransactions.ts
+++ b/src/lib/fetchTotalTransactions.ts
@@ -13,5 +13,8 @@ export const fetchTotalTransactions = async (): Promise<number | null> => {
       return res.json()
     })
     .then((data) => data.result.rows[0].num_txs)
-    .catch((err) => console.error(`Error fetching total number of transactions: ${err.message}`))
+    .catch((err) => {
+      console.log(`Error fetching total number of transactions: ${err.message}`)
+      return null
+    })
 }


### PR DESCRIPTION
## What it solves
The Dune data fetching functions need to return `null` in the catch block, otherwise it cannot be serialized
