### PR TITLE
fix: cross-chain gas fee typo

### DIFF
--- a/src/components/Safenet/CrossChain/index.tsx
+++ b/src/components/Safenet/CrossChain/index.tsx
@@ -68,7 +68,7 @@ const CrossChain = () => (
         </Typography>
 
         <Typography className={css.text}>
-          Cross-chain interactions are simplified. Say goodbye to gas free hassles and enjoy a seamless, stress-free
+          Cross-chain interactions are simplified. Say goodbye to gas fee hassles and enjoy a seamless, stress-free
           experience.
         </Typography>
       </div>


### PR DESCRIPTION
## What it solves

Typo regarding cross-chain gas fee.

## How this PR fixes it

Changes "gas free" to "gas _fee_".