### PR TITLE
fix(lint): use correct `variant` of `Typography`

### DIFF
--- a/src/components/Agentathon/Partners/index.tsx
+++ b/src/components/Agentathon/Partners/index.tsx
@@ -17,7 +17,7 @@ export default function Partners({ caption, items }: BaseBlock) {
             key={index}
           >
             {item.image?.src && <img src={item.image.src} className={css.itemImage} alt={item.image.alt} />}
-            <Typography variant="body" className={css.itemTitle}>
+            <Typography variant="body1" className={css.itemTitle}>
               {item.title}
             </Typography>
           </a>


### PR DESCRIPTION
## What it solves

Resolves [lint issue](https://github.com/safe-global/safe-homepage/actions/runs/12985474982/job/36210411733)

## How this PR fixes it

A `Typography` elemnt was using an invalid `variant` (`body`). This corrects it to using `body1`.
